### PR TITLE
Add commonjs build output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "@babel/plugin-transform-modules-commonjs",
+      {
+        "strict": true
+      }
+    ]
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,8 @@
       "@babel/plugin-transform-modules-commonjs",
       {
         "strict": true
-      }
-    ]
+      },
+    ],
+    "add-module-exports"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+dist
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -2,19 +2,27 @@
   "name": "es-module-lexer",
   "version": "0.1.2",
   "description": "Lexes ES modules returning their import/export metadata",
-  "main": "lexer.js",
+  "main": "dist/lexer.js",
+  "module": "lexer.js",
   "scripts": {
     "test": "mocha -r esm -u tdd test/unit.js",
+    "build": "babel lexer.js --out-dir dist --plugins @babel/plugin-transform-modules-commonjs",
     "bench": "node -r esm bench"
   },
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/cli": "^7.5.5",
+    "@babel/plugin-transform-modules-commonjs": "^7.5.0",
     "esm": "^3.0.84",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",
     "pretty-ms": "^5.0.0"
   },
-  "files": ["lexer.js"],
+  "files": [
+    "lexer.js",
+    "dist"
+  ],
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "lexer.js",
   "scripts": {
     "test": "mocha -r esm -u tdd test/unit.js",
-    "build": "babel lexer.js --out-dir dist --plugins @babel/plugin-transform-modules-commonjs",
+    "build": "babel lexer.js --out-dir dist",
     "bench": "node -r esm bench"
   },
   "author": "Guy Bedford",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.5.5",
     "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
     "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+    "babel-plugin-add-module-exports": "^1.0.2",
     "esm": "^3.0.84",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",


### PR DESCRIPTION
This adds a simple build command which only transforms esm to commonjs for use in node. 

I know you can use the experimental modules flag, but we can't ask our users to do this as well so we have to stick to commonjs in node for now. We could do it in our package if you don't want this here, but I think others will run into this as well if they want to use it.

`main` is pointing to the commonjs build, and `module` is pointing to the esm build. 