### PR TITLE
support object destructuring in export

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -58,7 +58,7 @@ suite('Lexer', () => {
     assert.equal(d, -1);
     assert.equal(source.slice(s, e), 'test-dep');
 
-    assert.equal(exports.length, 1); 
+    assert.equal(exports.length, 1);
     assert.equal(exports[0], 'default');
   });
 
@@ -97,7 +97,7 @@ suite('Lexer', () => {
         // not a dynamic import!
         import(not1) {}
       });
-      { 
+      {
         // is a dynamic import!
         import(is1);
       }
@@ -131,7 +131,7 @@ suite('Lexer', () => {
       export function f () {
         g();
       }
-      
+
       import { g } from './test-circular2.js';
     `;
     const [imports, exports] = parse(source);
@@ -235,5 +235,25 @@ function x() {
     assert.equal(imports.length, 0);
     assert.equal(exports.length, 1);
     assert.equal(exports[0], 'a');
+  });
+
+  test('Object destructuring in export', () => {
+    const source = `
+      export const { a, b } = foo;
+    `;
+    const [, exports] = parse(source);
+    assert.equal(exports.length, 2);
+    assert.equal(exports[0], 'a');
+    assert.equal(exports[1], 'b');
+  });
+
+  test('Object destructuring with renames in export', () => {
+    const source = `
+      export const { a: foo, b } = foo;
+    `;
+    const [, exports] = parse(source);
+    assert.equal(exports.length, 2);
+    assert.equal(exports[0], 'foo');
+    assert.equal(exports[1], 'b');
   });
 });


### PR DESCRIPTION
Fixes https://github.com/guybedford/es-module-lexer/issues/2

We could do a fallthrough to the regular export handling, but the renames are different (`as` and `:`). I'm not sure if that will cause unintended side effects.

I left out array destructuring for now, as it's a pretty exotic use case.