### PR TITLE
fix template literals with dollar signs

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -156,7 +156,7 @@ function tryParseImportStatement () {
 function tryParseExportStatement () {
   if (readPrecedingKeyword(i + 5) !== 'export' || readToWsOrPunctuator(i + 6) !== '')
     return;
-        
+
   let name;
   charCode = str.charCodeAt(i += 6);
   commentWhitespace();
@@ -268,13 +268,11 @@ function commentWhitespace () {
 
 function templateString () {
   while (charCode = str.charCodeAt(++i)) {
-    if (charCode === 36/*$*/) {
-      charCode = str.charCodeAt(++i);
-      if (charCode === 123/*{*/) {
-        templateStack.push(templateDepth);
-        templateDepth = ++braceDepth;
-        return;
-      }
+    if (charCode === 36/*$*/ && str.charCodeAt(i + 1) === 123/*{*/) {
+      charCode = str.charCodeAt(i += 2);
+      templateStack.push(templateDepth);
+      templateDepth = ++braceDepth;
+      return;
     }
     else if (charCode === 96/*`*/) {
       return;

--- a/test/unit.js
+++ b/test/unit.js
@@ -58,7 +58,7 @@ suite('Lexer', () => {
     assert.equal(d, -1);
     assert.equal(source.slice(s, e), 'test-dep');
 
-    assert.equal(exports.length, 1); 
+    assert.equal(exports.length, 1);
     assert.equal(exports[0], 'default');
   });
 
@@ -97,7 +97,7 @@ suite('Lexer', () => {
         // not a dynamic import!
         import(not1) {}
       });
-      { 
+      {
         // is a dynamic import!
         import(is1);
       }
@@ -131,7 +131,7 @@ suite('Lexer', () => {
       export function f () {
         g();
       }
-      
+
       import { g } from './test-circular2.js';
     `;
     const [imports, exports] = parse(source);
@@ -235,5 +235,21 @@ function x() {
     assert.equal(imports.length, 0);
     assert.equal(exports.length, 1);
     assert.equal(exports[0], 'a');
+  });
+
+  test('Template string expression ambiguity', () => {
+    const source = `
+      \`$\`
+      import 'a';
+      \`\`
+      export { b };
+      \`a$b\`
+      import(\`$\`);
+      \`{$}\`
+    `;
+    const [imports, exports] = parse(source);
+    assert.equal(imports.length, 2);
+    assert.equal(exports.length, 1);
+    assert.equal(exports[0], 'b');
   });
 });


### PR DESCRIPTION
FYI we are now using this to resolve bare imports in https://github.com/open-wc/open-wc/tree/master/packages/es-dev-server. 

I started using it at work on a large codebase, and this is the only bug that came up. Pretty good I think :)

Fixes https://github.com/guybedford/es-module-lexer/issues/4