### PR TITLE
Add text-encoder import for node

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,4 +15,7 @@ const minified = MINIFY && terser.minify(jsSourceProcessed, {
   }
 });
 
+const nodeHeader = `import { TextEncoder } from 'util';`;
+
 fs.writeFileSync('./dist/lexer.js', minified ? minified.code : jsSourceProcessed);
+fs.writeFileSync('./dist/lexer.cjs.js', `${nodeHeader}${minified ? minified.code : jsSourceProcessed}`);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/lexer.js",
   "scripts": {
     "test": "mocha -r esm -b -u tdd test/*.js",
-    "build": "node --experimental-modules build.js && babel dist/lexer.js | terser -o dist/lexer.cjs.js",
+    "build": "node --experimental-modules build.js && babel dist/lexer.cjs.js | terser -o dist/lexer.cjs.js",
     "build-wasm": "make lib/lexer.wasm && node --experimental-modules build.js",
     "bench": "node --experimental-modules --expose-gc bench/index.js",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
`TextEncoder` is a global variable in node 12, but not in node 10. This adds a small build step to add the import for the node build.