### PR TITLE
Better parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { init, parse } from 'es-module-lexer/dist/es-module-lexer.js';
     import /*comment!*/.meta.asdf;
   `;
 
-  const [imports, exports] = parse(source);
+  const [imports, exports] = parse(source, 'optional-sourcename');
 
   // Returns "asdf"
   source.substring(imports[0].s, imports[0].e);

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -1,4 +1,4 @@
-export function parse (source, name) {
+export function parse (source, name = '@') {
   if (!wasm)
     return init.then(() => parse(source));
 
@@ -10,7 +10,7 @@ export function parse (source, name) {
   copy(source, new Uint16Array(wasm.memory.buffer, wasm.sa(source.length), source.length + 1));
 
   if (!wasm.parse())
-    throw Object.assign(new Error(`Error parsing ${name || '?'} at ${wasm.e()}.`), { idx: wasm.e() });
+    throw Object.assign(new Error(`Parse error ${name}:${source.slice(0, wasm.e()).split('\n').length}:${wasm.e() - source.lastIndexOf('\n', wasm.e()) - 1}`), { idx: wasm.e() });
 
   const imports = [], exports = [];
   while (wasm.ri()) imports.push({ s: wasm.is(), e: wasm.ie(), d: wasm.id() });

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -11,6 +11,7 @@ suite('Invalid syntax', () => {
       assert(false, 'Should error');
     }
     catch (err) {
+      console.log(err);
       assert.equal(err.idx, 11);
     }
   });


### PR DESCRIPTION
The parse function can now take a source name and properly returns the line and column. It adds a few bytes but seems worth it.