### PR TITLE
Update package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/lexer.cjs",
   "module": "dist/lexer.js",
   "exports": {
-    "require": "dist/lexer.cjs",
-    "import": "dist/lexer.js"
+    "require": "./dist/lexer.cjs",
+    "import": "./dist/lexer.js"
   },
   "scripts": {
     "test": "NODE_OPTIONS=\"--experimental-modules\" mocha -b -u tdd test/*.cjs",


### PR DESCRIPTION
This PR updates the `package.json` exports field to include valid paths (starting with `./`) as currently the exports are not following the spec (defined here https://nodejs.org/api/esm.html#esm_package_exports) 

We're trying to use `es-module-lexer` in snowpack but the current exports are breaking on Node 13 (you can see the full issue here https://github.com/pikapkg/snowpack/pull/208) so hopefully this should fix that issue for us and others!
 