### PR TITLE
Only use atob when there is a `window`

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -43,7 +43,7 @@ function copyLE (src, outBuf16) {
 let wasm;
 
 export const init = WebAssembly.compile(
-  (binary => typeof atob === 'function' ? Uint8Array.from(atob(binary), x => x.charCodeAt(0)) : Buffer.from(binary, 'base64'))
+  (binary => typeof window !== 'undefined' && typeof atob === 'function' ? Uint8Array.from(atob(binary), x => x.charCodeAt(0)) : Buffer.from(binary, 'base64'))
   ('WASM_BINARY')
 )
 .then(WebAssembly.instantiate)


### PR DESCRIPTION
Avoids any global called atob altering the behaviour in Node.js. Fixes https://github.com/guybedford/es-module-lexer/issues/57.