### PR TITLE
fix: n is exist in all ImportSpecifier

### DIFF
--- a/types/lexer.d.ts
+++ b/types/lexer.d.ts
@@ -19,7 +19,7 @@ export interface ImportSpecifier {
    * imports3[0].n;
    * // Returns undefined
    */
-  readonly n?: string;
+  readonly n: string | undefined;
   /**
    * Start of module specifier
    * 


### PR DESCRIPTION
In all ImportSpecifier, `n` field exists, it will be `string` or `undefined`. 
So `'n' in imports[0]` will always be true.
So we should use `n: string | undefined` rather than `n?: string`.