### PR TITLE
Remove window !== undefined check

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -57,7 +57,7 @@ function copyLE (src, outBuf16) {
 let wasm;
 
 export const init = WebAssembly.compile(
-  (binary => typeof atob === 'function' ? Uint8Array.from(atob(binary), x => x.charCodeAt(0)) : Buffer.from(binary, 'base64'))
+  (binary => typeof Buffer !== 'undefined' ? Buffer.from(binary, 'base64') : Uint8Array.from(atob(binary), x => x.charCodeAt(0)))
   ('WASM_BINARY')
 )
 .then(WebAssembly.instantiate)

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -57,7 +57,7 @@ function copyLE (src, outBuf16) {
 let wasm;
 
 export const init = WebAssembly.compile(
-  (binary => typeof window !== 'undefined' && typeof atob === 'function' ? Uint8Array.from(atob(binary), x => x.charCodeAt(0)) : Buffer.from(binary, 'base64'))
+  (binary => typeof atob === 'function' ? Uint8Array.from(atob(binary), x => x.charCodeAt(0)) : Buffer.from(binary, 'base64'))
   ('WASM_BINARY')
 )
 .then(WebAssembly.instantiate)


### PR DESCRIPTION
Web Workers don't have `window` defined, so this check was causing workers to error from calling an undefined `Buffer.from` function.

After this change, es-module-lexer can be used in web workers.

I couldn't think of a reason that `window` needed to be checked in addition to `atob`, but I might have missed something.

Note that Node 16 now supports `atob`, so this change will cause Node 16+ to use `Uint8Array.from(atob())` instead of `Buffer.from()`, which seems fine. (In some future version that assumes Node 16+, you could drop the check entirely).