### PR TITLE
Fix unable to import in node 12.18 ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "main": "dist/lexer.cjs",
   "module": "dist/lexer.js",
   "types": "types/lexer.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/lexer.js",
+      "require": "./dist/lexer.cjs"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
+  },
   "scripts": {
     "test": "NODE_OPTIONS=\"--experimental-modules\" mocha -b -u tdd test/*.cjs",
     "build": "node --experimental-modules build.js && babel dist/lexer.js | terser -o dist/lexer.cjs",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
   "module": "dist/lexer.js",
   "types": "types/lexer.d.ts",
   "exports": {
-    ".": {
-      "module" "./dist/lexer.js",
-      "import": "./dist/lexer.js",
-      "require": "./dist/lexer.cjs"
-    }
+    "module" "./dist/lexer.js",
+    "import": "./dist/lexer.js",
+    "require": "./dist/lexer.cjs"
   },
   "scripts": {
     "test": "NODE_OPTIONS=\"--experimental-modules\" mocha -b -u tdd test/*.cjs",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
   "types": "types/lexer.d.ts",
   "exports": {
     ".": {
+      "module" "./dist/lexer.js",
       "import": "./dist/lexer.js",
       "require": "./dist/lexer.cjs"
-    },
-    "./package.json": "./package.json",
-    "./": "./"
+    }
   },
   "scripts": {
     "test": "NODE_OPTIONS=\"--experimental-modules\" mocha -b -u tdd test/*.cjs",


### PR DESCRIPTION
This PR adds some fields to `package.json` to be able to use this library with native ESM mode in node 12.18 and upwards. Without these node fails with the following error:

```bash
(node:1744) ExperimentalWarning: The ESM module loader is experimental.
file:///opt/build/repo/packages/wmr/src/lib/transform-imports.js:1
import { parse } from 'es-module-lexer';
         ^^^^^
SyntaxError: The requested module 'es-module-lexer' does not provide an export named 'parse'
    at ModuleJob._instantiate (internal/modules/esm/module_job.js:92:21)
    at async ModuleJob.run (internal/modules/esm/module_job.js:107:20)
    at async Loader.import (internal/modules/esm/loader.js:179:24)
```

Ran into this while working on https://github.com/preactjs/wmr/pull/715 .

Explanation of the fix:

```js
"exports": {
  // Main/default entry point
  ".": {
    "import": "./dist/lexer.js",
    // CommonJS entry point
    "require": "./dist/lexer.cjs"
  },
  // If any module wants to import `es-module-lexerpackage.json` for some reason
  // (grabbing package.version or something)
  "./package.json": "./package.json",
  // Old-style deep imports, like `require("es-module-lexer/dist/lexer.js")`
  "./": "./"
},
```

Fixes #54 .