### PR TITLE
Add missing typings for import assertions

### DIFF
--- a/types/lexer.d.ts
+++ b/types/lexer.d.ts
@@ -55,6 +55,12 @@ export interface ImportSpecifier {
    * Otherwise this is `-1`.
    */
   readonly d: number;
+
+  /**
+   * If this import has an import assertion, this is the start value.
+   * Otherwise this is `-1`.
+   */
+  readonly a: number;
 }
 
 /**


### PR DESCRIPTION
Past PRs #74 and #75 added support for import assertions, but the TypeScript types haven't been updated yet. This PR addresses that.