### PR TITLE
Use valid ES6 syntax for catching the error

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -31,7 +31,7 @@ export function parse (source, name = '@') {
     try {
       return (0, eval)(str);
     }
-    catch {}
+    catch (e) {}
   }
 
   return [imports, exports, !!wasm.f()];


### PR DESCRIPTION
It's a minor change and it's fixing the syntax, so it's a valid ES6. (It led to issue with asset precompilation when using more strict syntax checks.)