### PR TITLE
feat: mark facade in return-type of `parse`.

### DIFF
--- a/types/lexer.d.ts
+++ b/types/lexer.d.ts
@@ -81,5 +81,6 @@ export function parse(
   name?: string
 ): readonly [
   imports: ReadonlyArray<ImportSpecifier>,
-  exports: ReadonlyArray<string>
+  exports: ReadonlyArray<string>,
+  facade: boolean
 ];


### PR DESCRIPTION
typo update.