### PR TITLE
fix: normalize spaces to tabs in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ lib/lexer.asm.js: src/lexer.h src/lexer.c
 	rm lib/lexer.js
 	cp lib/lexer.js.bak lib/lexer.js
 	echo "Manual changes to lib/lexer.asm.js are needed for building:
-    - Module["asm"] -> function asmInit (global, env, buffer) { ... }
-    - In EMSCRIPTEN_END_FUNCS, underscores (_) are removed from all exported function names
-    - In EMSCRIPTEN_END_FUNCS, rename stackAllocate -> sta, setSource -> ses, parse -> p
-    - Manual tree shaking is applied to remove the malloc implementation to reduce the footprint (optional)"
+	- Module["asm"] -> function asmInit (global, env, buffer) { ... }
+	- In EMSCRIPTEN_END_FUNCS, underscores (_) are removed from all exported function names
+	- In EMSCRIPTEN_END_FUNCS, rename stackAllocate -> sta, setSource -> ses, parse -> p
+	- Manual tree shaking is applied to remove the malloc implementation to reduce the footprint (optional)"
 
 clean:
 	rm lib/*

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ To build download the WASI SDK from https://github.com/WebAssembly/wasi-sdk/rele
 
 The Makefile assumes the existence of "wasi-sdk-11.0" and "wabt" (optional) as sibling folders to this project.
 
-The build through the Makefile is then run via `make lib/lexer.wasm`, which can also be triggered via `npm run build-wasm` to create `dist/lexer.js`.
+The build through the Makefile is then run via `make lib/lexer.wasm`, which can also be triggered via `npm run build:wasm` to create `dist/lexer.js`.
 
 On Windows it may be preferable to use the Linux subsystem.
 


### PR DESCRIPTION
This PR tried to normalize indent in `Makefile`, in most of `make` programs (e.g. default `make` macOS), all indents in Makefile are expected real tabs, see details [here](https://stackoverflow.com/questions/9580566/missing-separator-in-makefile).

BTW, I corrected little error in README