### PR TITLE
Truly rebuild wasm every time on CI, better instructions for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Install wasi-sdk
         shell: bash
-        if: runner.os != 'Windows'
         env:
           PROJ_ROOT: ${{ steps.preparation.outputs.PROJ_ROOT }}
         run: |
@@ -52,6 +51,9 @@ jobs:
           fi
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             export WASI_OS="macos";
+          fi
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            export WASI_OS="mingw";
           fi
 
           curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-${WASI_OS}.tar.gz -O

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
           PROJ_ROOT: ${{ steps.preparation.outputs.PROJ_ROOT }}
         run: |
           cd $PROJ_ROOT;
+          rm lib/lexer.wasm;
           make lib/lexer.wasm && npm run build:wasm;
           # test
           npm run test:wasm;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ES Module Lexer
 
-[![Build Status][travis-image]][travis-url]
+[![Build Status][actions-image]][actions-url]
 
 A JS module syntax lexer used in [es-module-shims](https://github.com/guybedford/es-module-shims).
 
@@ -232,13 +232,15 @@ test/samples/*.js (3123 KiB)
 
 ### Building
 
-To build download the WASI SDK from https://github.com/WebAssembly/wasi-sdk/releases.
+To build download the WASI SDK 12.0 from https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-12.
 
-The Makefile assumes the existence of "wasi-sdk-11.0" and "wabt" (optional) as sibling folders to this project.
+- [Linux](https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz)
+- [Windows (MinGW)](https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-mingw.tar.gz)
+- [macOS](https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-macos.tar.gz)
+
+The Makefile assumes the existence of "wasi-sdk-12.0" and "wabt" (optional) as sibling folders to this project.
 
 The build through the Makefile is then run via `make lib/lexer.wasm`, which can also be triggered via `npm run build:wasm` to create `dist/lexer.js`.
-
-On Windows it may be preferable to use the Linux subsystem.
 
 After the Web Assembly build, the CJS build can be triggered via `npm run build`.
 
@@ -246,6 +248,6 @@ After the Web Assembly build, the CJS build can be triggered via `npm run build`
 
 MIT
 
-[travis-url]: https://travis-ci.org/guybedford/es-module-lexer
-[travis-image]: https://travis-ci.org/guybedford/es-module-lexer.svg?branch=master
+[actions-image]: https://github.com/guybedford/es-module-lexer/actions/workflows/build.yml/badge.svg
+[actions-url]: https://github.com/guybedford/es-module-lexer/actions/workflows/build.yml
 


### PR DESCRIPTION
Hi, [The previous PR](https://github.com/guybedford/es-module-lexer/pull/94) only run tests for `.wasm` built on developer's local machine, but not rebuild `.wasm` on CI, this PR do that.

BTW, I found [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) supported Windows officially by MinGW, so we can just build directly on Windows rather than on its Linux subsystem (I updated the README!)