### PR TITLE
fix: asm.js analysis memory limits

### DIFF
--- a/lib/lexer.asm.js
+++ b/lib/lexer.asm.js
@@ -19,7 +19,7 @@ let source, name;
 export function parse (_source, _name = '@') {
   source = _source;
   name = _name;
-  const memBound = source.length * 2 + (2 << 17);
+  const memBound = source.length * 2 + (2 << 18);
   if (memBound > allocSize || !asm) {
     while (memBound > allocSize) allocSize *= 2;
     asmBuffer = new ArrayBuffer(allocSize);
@@ -28,7 +28,7 @@ export function parse (_source, _name = '@') {
     // 2 bytes per string code point
     // + analysis space
     // remaining space is stack space
-    addr = asm.su(source.length * 2 + (2 << 16));
+    addr = asm.su(source.length * 2 + (2 << 17));
   }
   const len = source.length + 1;
   asm.ses(addr);

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -19,7 +19,7 @@ let source, name;
 export function parse (_source, _name = '@') {
   source = _source;
   name = _name;
-  const memBound = source.length * 2 + (2 << 17);
+  const memBound = source.length * 2 + (2 << 18);
   if (memBound > allocSize || !asm) {
     while (memBound > allocSize) allocSize *= 2;
     asmBuffer = new ArrayBuffer(allocSize);
@@ -28,7 +28,7 @@ export function parse (_source, _name = '@') {
     // 2 bytes per string code point
     // + analysis space
     // remaining space is stack space
-    addr = asm.su(source.length * 2 + (2 << 16));
+    addr = asm.su(source.length * 2 + (2 << 17));
   }
   const len = source.length + 1;
   asm.ses(addr);


### PR DESCRIPTION
This further adjusts the analysis memory bound size, which was still hitting limits.