### PR TITLE
fix: fixed allocation calculation

### DIFF
--- a/lib/lexer.asm.js
+++ b/lib/lexer.asm.js
@@ -1,4 +1,4 @@
-let asm, asmBuffer, allocSize = 2<<18, addr;
+let asm, asmBuffer, allocSize = 2<<19, addr;
 
 const copy = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1 ? function (src, outBuf16) {
   const len = src.length;
@@ -19,16 +19,17 @@ let source, name;
 export function parse (_source, _name = '@') {
   source = _source;
   name = _name;
+  // 2 bytes per string code point
+  // + analysis space (2^17)
+  // remaining space is EMCC stack space (2^17)
   const memBound = source.length * 2 + (2 << 18);
   if (memBound > allocSize || !asm) {
     while (memBound > allocSize) allocSize *= 2;
     asmBuffer = new ArrayBuffer(allocSize);
     copy(words, new Uint16Array(asmBuffer, 16, words.length));
     asm = asmInit(typeof self !== 'undefined' ? self : global, {}, asmBuffer);
-    // 2 bytes per string code point
-    // + analysis space
-    // remaining space is stack space
-    addr = asm.su(source.length * 2 + (2 << 17));
+    // lexer.c bulk allocates string space + analysis space
+    addr = asm.su(allocSize - (2<<17));
   }
   const len = source.length + 1;
   asm.ses(addr);

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -1,4 +1,4 @@
-let asm, asmBuffer, allocSize = 2<<18, addr;
+let asm, asmBuffer, allocSize = 2<<19, addr;
 
 const copy = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1 ? function (src, outBuf16) {
   const len = src.length;
@@ -19,16 +19,17 @@ let source, name;
 export function parse (_source, _name = '@') {
   source = _source;
   name = _name;
+  // 2 bytes per string code point
+  // + analysis space (2^17)
+  // remaining space is EMCC stack space (2^17)
   const memBound = source.length * 2 + (2 << 18);
   if (memBound > allocSize || !asm) {
     while (memBound > allocSize) allocSize *= 2;
     asmBuffer = new ArrayBuffer(allocSize);
     copy(words, new Uint16Array(asmBuffer, 16, words.length));
     asm = asmInit(typeof self !== 'undefined' ? self : global, {}, asmBuffer);
-    // 2 bytes per string code point
-    // + analysis space
-    // remaining space is stack space
-    addr = asm.su(source.length * 2 + (2 << 17));
+    // lexer.c bulk allocates string space + analysis space
+    addr = asm.su(allocSize - (2<<17));
   }
   const len = source.length + 1;
   asm.ses(addr);


### PR DESCRIPTION
A further asm.js memory allocation fix - the initial stack allocation should be constant based on the allocation bound being chosen, and not at all depending on the source size as the memory will be shared for other sources for efficiency. Previously, parsing a small string followed by a long string would underallocate the initial buffer and then overflow for the next parser operation!

This should finally be stability on these issues for now.