### PR TITLE
Remove uint32_t point parameter from parse declaration

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -217,7 +217,7 @@ bool f () {
   return facade;
 }
 
-bool parse (uint32_t point);
+bool parse ();
 
 void tryParseImportStatement ();
 void tryParseExportStatement ();


### PR DESCRIPTION
Apologies if I misunderstood something, but it seems that the `parse` declaration in `lexer.h` has a `point` parameter, which is missing from the implementation in `lexer.c`, and doesn't seem to be referenced anywhere. So this PR removes the parameter from `lexer.h`.

I noticed this because the emscripten toolchain I'm using raises this a `conflicting types for 'parse'` error.