### PR TITLE
Adding `types` entry to exports map.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "types/lexer.d.ts",
   "exports": {
     ".": {
+      "types": "./types/lexer.d.ts",
       "module": "./dist/lexer.js",
       "import": "./dist/lexer.js",
       "require": "./dist/lexer.cjs"


### PR DESCRIPTION
When using this package in a TypeScript environment which uses `moduleResolution: 'nodenext'`, TypeScript won't find the typings unless the `exports` map entries include a `types` key. (E.g. it ignores the one at root.)

Another remedy is to include typings right next to the source. I believe TypeScript will find them this way as well.

Tested locally by adding this entry made TS happy. :)
