### PR TITLE
build(deps-dev): update dev dependencies to latest

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -33,7 +33,7 @@ Promise.resolve().then(async () => {
 		{
 			const start = process.hrtime.bigint();
 			var { parse } = await import('../dist/lexer.asm.js');
-			console.log(`> ${c.bold.green(Math.round(Number(process.hrtime.bigint() - start) / 1e6) + 'ms')}`);
+			console.log(`> ${c.bold().green(Math.round(Number(process.hrtime.bigint() - start) / 1e6) + 'ms')}`);
 		}
 	
 		doRun();
@@ -46,7 +46,7 @@ Promise.resolve().then(async () => {
 			const start = process.hrtime.bigint();
 			var { parse, init } = await import('../dist/lexer.js');
 			await init;
-			console.log(`> ${c.bold.green(Math.round(Number(process.hrtime.bigint() - start) / 1e6) + 'ms')}`);
+			console.log(`> ${c.bold().green(Math.round(Number(process.hrtime.bigint() - start) / 1e6) + 'ms')}`);
 		}
 	
 		doRun();
@@ -61,14 +61,14 @@ Promise.resolve().then(async () => {
 				totalSize += size;
 				total += timeRun(code);
 			});
-			console.log(c.bold.cyan(`test/samples/*.js (${Math.round(totalSize / 1e3)} KiB)`));
-			console.log(`> ${c.bold.green(total + 'ms')}`);
+			console.log(c.bold().cyan(`test/samples/*.js (${Math.round(totalSize / 1e3)} KiB)`));
+			console.log(`> ${c.bold().green(total + 'ms')}`);
 			gc();
 		}
 	
 		console.log(`\nWarm Runs (average of ${n} runs)`);
 		files.forEach(({ file, code, size }) => {
-			console.log(c.bold.cyan(`${file} (${Math.round(size / 1e3)} KiB)`));
+			console.log(c.bold().cyan(`${file} (${Math.round(size / 1e3)} KiB)`));
 	
 			let total = 0;
 			for (let i = 0; i < n; i++) {
@@ -76,7 +76,7 @@ Promise.resolve().then(async () => {
 				gc();
 			}
 	
-			console.log(`> ${c.bold.green((total / n) + 'ms')}`);
+			console.log(`> ${c.bold().green((total / n) + 'ms')}`);
 		});
 	
 		console.log(`\nWarm Runs, All Samples (average of ${n} runs)`);
@@ -87,8 +87,8 @@ Promise.resolve().then(async () => {
 					total += timeRun(code);
 				});
 			}
-			console.log(c.bold.cyan(`test/samples/*.js (${Math.round(totalSize / 1e3)} KiB)`));
-			console.log(`> ${c.bold.green((total / n) + 'ms')}`);
+			console.log(c.bold().cyan(`test/samples/*.js (${Math.round(totalSize / 1e3)} KiB)`));
+			console.log(`> ${c.bold().green((total / n) + 'ms')}`);
 		}
 	}
 });

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -62,8 +62,10 @@ node ./node_modules/@swc/cli/bin/swc.js $DEP -o $TARGET --no-swcrc -C jsc.parser
 name = 'build:types'
 target = 'types/lexer.d.ts'
 dep = 'src/lexer.ts'
+# `--types node` is explicit: TypeScript 6 no longer auto-includes @types/node
+# for a file passed on the command line, so `Buffer` (lexer.ts) would error.
 run = '''
-  tsc --strict --declaration --emitDeclarationOnly --outdir types src/lexer.ts
+  tsc --strict --declaration --emitDeclarationOnly --types node --outdir types src/lexer.ts
 '''
 
 [[task]]

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^7.5.5",
-    "@babel/core": "^7.5.5",
-    "@babel/plugin-transform-modules-commonjs": "^7.5.0",
-    "@swc/cli": "^0.1.57",
-    "@swc/core": "^1.2.224",
-    "@types/node": "^18.7.1",
-    "kleur": "^2.0.2",
-    "mocha": "^5.2.0",
-    "terser": "^5.19.4",
-    "typescript": "^4.7.4"
+    "@babel/cli": "^7.29.7",
+    "@babel/core": "^7.29.7",
+    "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+    "@swc/cli": "^0.8.1",
+    "@swc/core": "^1.15.41",
+    "@types/node": "^25.9.3",
+    "kleur": "^4.1.5",
+    "mocha": "^11.7.6",
+    "terser": "^5.48.0",
+    "typescript": "^6.0.3"
   },
   "files": [
     "dist",

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -37,7 +37,7 @@ function assertExportIs(source, actual, expected) {
 }
 
 suite('Lexer', () => {
-  beforeEach(async () => await init);
+  setup(async () => await init);
 
   test('Division of `of` identifier in for statement', () => {
     // `of` as identifier on the LHS of a binary expression with `/`,
@@ -1765,7 +1765,7 @@ function x() {
 });
 
 suite('Invalid syntax', () => {
-  beforeEach(async () => await init);
+  setup(async () => await init);
 
   test('Unterminated object', () => {
     const source = `


### PR DESCRIPTION
## Summary

Bumps all npm dev dependencies to latest. Two majors needed a coordinated change in the same commit, or a build step breaks:

1. `build:types` errored on `Buffer` — TypeScript 6 no longer auto-includes `@types/node` for a file passed on the `tsc` command line, so the call now passes `--types node`.
2. The unit suite threw `ReferenceError: beforeEach is not defined` at load — mocha 11's `tdd` UI dropped the bdd `beforeEach`, so its two hooks use the tdd `setup` alias.

The WASM/asm toolchain (`wasi-sdk`, `emscripten`) is intentionally untouched: emscripten `1.40.1-fastcomp` can't move without rewriting the asm.js post-processing, which is a build-system change rather than a dependency bump.

## Test plan

- [ ] `chomp build` produces `dist/` and `types/`
- [ ] `chomp test` (wasm + asm) is green