### PR TITLE
fix: report n for no-substitution template dynamic imports

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -254,13 +254,21 @@ function tryParseImportStatement () {
       if (source.charCodeAt(lastTokenPos) === 46/*.*/)
         return;
       // dynamic import indicated by positive d
-      const impt = addImport(startPos, pos + 1, 0, startPos);
-      curDynamicImport = impt;
       // try parse a string, to record a safe dynamic import string
       pos++;
       ch = commentWhitespace(true);
+      // The specifier start is recorded after leading whitespace/comments so it
+      // points at the literal, matching the C lexer (src/lexer.c).
+      const impt = addImport(startPos, pos, 0, startPos);
+      curDynamicImport = impt;
       if (ch === 39/*'*/ || ch === 34/*"*/) {
         stringLiteral(ch);
+      }
+      else if (ch === 96/*`*/ && noSubstitutionTemplate()) {
+        // A no-substitution template literal is a constant string, so it is a
+        // safe specifier exactly like a quoted one. An interpolated template
+        // leaves noSubstitutionTemplate() false and falls through to the open-
+        // token machinery, which records the import as unsafe (n stays unset).
       }
       else {
         pos--;
@@ -495,7 +503,9 @@ function readString (start, quote) {
       ++acornPos;
     }
     else {
-      if (isBr(ch)) syntaxError();
+      // Template literals (backtick quote) permit raw line breaks; string
+      // literals do not.
+      if (isBr(ch) && quote !== 96/*`*/) syntaxError();
       ++acornPos;
     }
   }
@@ -726,6 +736,28 @@ function templateString () {
       pos++;
   }
   syntaxError();
+}
+
+// pos AT the opening backtick. A no-substitution template literal (no ${...})
+// is a constant string, so a dynamic import can record it as a safe specifier.
+// On success consumes it, leaves pos AT the closing backtick and returns true.
+// On a substitution or EOF restores pos and returns false, leaving the literal
+// to the main loop's template handling.
+function noSubstitutionTemplate () {
+  const startPos = pos;
+  while (pos++ < end) {
+    const ch = source.charCodeAt(pos);
+    if (ch === 96/*`*/)
+      return true;
+    if (ch === 92/*\*/) {
+      pos++;
+      continue;
+    }
+    if (ch === 36/*$*/ && source.charCodeAt(pos + 1) === 123/*{*/)
+      break;
+  }
+  pos = startPos;
+  return false;
 }
 
 function blockComment (br) {

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -121,7 +121,7 @@ function readString (start, quote) {
       ++acornPos;
     }
     else {
-      if (isBr(ch)) syntaxError();
+      if (isBr(ch) && quote !== 96/*`*/) syntaxError();
       ++acornPos;
     }
   }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -331,6 +331,12 @@ void tryParseImportStatement () {
     else if (ch == '"') {
       stringLiteral(ch);
     }
+    else if (ch == '`' && noSubstitutionTemplate()) {
+      // A no-substitution template literal is a constant string, so it is a
+      // safe specifier exactly like a quoted one. An interpolated template
+      // leaves noSubstitutionTemplate() false and falls through to the open-
+      // token machinery, which records the import as unsafe (n stays unset).
+    }
     else {
       pos--;
       return;
@@ -821,6 +827,28 @@ void templateString () {
       pos++;
   }
   syntaxError();
+}
+
+// pos AT the opening backtick. A no-substitution template literal (no ${...})
+// is a constant string, so a dynamic import can record it as a safe specifier.
+// On success consumes it, leaves pos AT the closing backtick and returns true.
+// On a substitution or EOF restores pos and returns false, leaving the literal
+// to the main loop's template handling.
+bool noSubstitutionTemplate () {
+  char16_t* startPos = pos;
+  while (pos++ < end) {
+    char16_t ch = *pos;
+    if (ch == '`')
+      return true;
+    if (ch == '\\') {
+      pos++;
+      continue;
+    }
+    if (ch == '$' && *(pos + 1) == '{')
+      break;
+  }
+  pos = startPos;
+  return false;
 }
 
 void blockComment (bool br) {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -300,6 +300,7 @@ char16_t readExportAs (char16_t* startPos, char16_t* endPos);
 char16_t commentWhitespace (bool br);
 void regularExpression ();
 void templateString ();
+bool noSubstitutionTemplate ();
 void blockComment (bool br);
 void lineComment ();
 void stringLiteral (char16_t quote);

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -408,6 +408,33 @@ suite('Lexer', () => {
     assert.strictEqual(source.slice(impt.a, impt.se), 'attrs)');
   });
 
+  test(`Dynamic import no-substitution template specifier`, () => {
+    // A no-substitution template literal is a constant string, so n is set the
+    // same as for the quoted forms; an interpolated template has no constant
+    // value, so n stays undefined.
+    assert.strictEqual(parse('import("./x.js")')[0][0].n, './x.js');
+    assert.strictEqual(parse("import('./x.js')")[0][0].n, './x.js');
+    assert.strictEqual(parse('import(`./x.js`)')[0][0].n, './x.js');
+    assert.strictEqual(parse('import(`./a${x}.js`)')[0][0].n, undefined);
+  });
+
+  test(`Dynamic import template specifier with escapes and attributes`, () => {
+    // \\${ is an escaped dollar, not a substitution, so the literal is constant.
+    assert.strictEqual(parse('import(`./a\\${x}.js`)')[0][0].n, './a${x}.js');
+    // Quotes inside the template are ordinary characters.
+    assert.strictEqual(parse("import(`./'q\".js`)")[0][0].n, `./'q".js`);
+    // A constant template specifier is still detected when an import attribute
+    // argument follows it.
+    const [[impt]] = parse("import(`./x.js`, { with: { type: 'json' } })");
+    assert.strictEqual(impt.n, './x.js');
+    assert.notStrictEqual(impt.a, -1);
+  });
+
+  test(`Dynamic import multi-line no-substitution template specifier`, () => {
+    // Template literals permit raw line breaks; the constant value keeps them.
+    assert.strictEqual(parse('import(`./a\nb.js`)')[0][0].n, './a\nb.js');
+  });
+
   test(`Simple export destructuring`, () => {
     const source = `
       export const{URI,Utils,...Another}=LIB


### PR DESCRIPTION
## Summary

A dynamic import whose specifier is a no-substitution template literal
(`` import(`./x.js`) ``) returned `n: undefined`, while the quoted forms
returned the specifier. A template with no `${...}` is a constant string, so it
now records a safe specifier the same as a quoted one; an interpolated template
has no constant value and still returns `undefined`. This surfaces with minified
Rolldown bundles, which rewrite dynamic-import specifiers to template literals.

`src/lexer.c` and the `lexer.js` fallback are updated together. `readString`
tolerates raw line breaks for a backtick quote, since template literals permit
them and string literals do not.

## Drive-by

* The `lexer.js` fallback recorded the specifier start before skipping leading
  whitespace/comments, so `import(/* c */ "x")` mis-decoded `n`; it now records
  the start after, matching the C lexer.

## Test plan

- [ ] `chomp test` (WASM + ASM): new `Dynamic import …template specifier` cases
  in `test/_unit.cjs` (quoted vs no-substitution vs interpolated, escapes,
  attributes, multi-line)

Fixes #198