### PR TITLE
feat: expose export statement start position as ss

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ import { init, parse } from 'es-module-lexer';
   source.slice(exports[1].s, exports[1].e);
   // Returns "q"
   source.slice(exports[1].ls, exports[1].le);
+
+  // "ss" = export statement start (only the start is tracked, not the end)
+  // Returns "export"
+  source.slice(exports[0].ss, exports[0].ss + 6);
+
   // Returns "'external name'"
   source.slice(exports[2].s, exports[2].e);
   // Returns -1

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -101,7 +101,7 @@ run = """
 	${{ EMSDK_PATH }}/emsdk activate 6.0.0
 
 	${{ EMSDK_PATH }}/upstream/emscripten/emcc src/lexer.c -o lib/lexer.wasm -Oz -flto --no-entry -s STANDALONE_WASM=1 \
-	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','___heap_base']" \
+	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_ess','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','___heap_base']" \
 	-s SUPPORT_LONGJMP=0 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
 """
 
@@ -114,7 +114,7 @@ run = """
 	${{ EMSDK_FASTCOMP_PATH }}/emsdk activate 1.40.1-fastcomp
 
 	${{ EMSDK_FASTCOMP_PATH }}/fastcomp/emscripten/emcc ./src/lexer.c -o lib/lexer.emcc.js -s WASM=0 -Oz --closure 1 \
-	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','_setSource']" \
+	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_ess','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','_setSource']" \
 	-s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s GLOBAL_BASE=8 \
 	-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s TOTAL_STACK=4997968 -s --separate-asm -Wno-logical-op-parentheses -Wno-parentheses
 """
@@ -134,7 +134,7 @@ run = """
 	${{ EMSDK_FASTCOMP_PATH }}/emsdk activate 1.40.1-fastcomp
 
 	${{ EMSDK_FASTCOMP_PATH }}/fastcomp/emscripten/emcc ./src/lexer.c -o lib/lexer.layout.js -s WASM=0 -Oz --closure 0 \
-	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','_setSource']" \
+	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_ess','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','_setSource']" \
 	-s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s GLOBAL_BASE=8 \
 	-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s TOTAL_STACK=4997968 -Wno-logical-op-parentheses -Wno-parentheses
 """

--- a/lexer.js
+++ b/lexer.js
@@ -12,6 +12,7 @@ let source, pos, end,
   templateStack,
   imports,
   exports,
+  exportStatementStart,
   name;
 
 function addImport (ss, s, e, d) {
@@ -26,6 +27,7 @@ function addExport (s, e, ls, le) {
     e,
     ls,
     le,
+    ss: exportStatementStart,
     n: s[0] === '"' ? readString(s, '"') : s[0] === "'" ? readString(s, "'") : source.slice(s, e),
     ln: ls[0] === '"' ? readString(ls, '"') : ls[0] === "'" ? readString(ls, "'") : source.slice(ls, le)
   });
@@ -339,8 +341,13 @@ function tryParseExportStatement () {
 
   let ch = commentWhitespace(true);
 
+  // Only commit the statement start once this is a real export: skipExpression
+  // re-enters here for an `export`-prefixed identifier (e.g. `exports`) in an
+  // initializer, which would otherwise clobber the start for later bindings.
   if (pos === curPos && !isPunctuator(ch))
     return;
+
+  exportStatementStart = sStartPos;
 
   switch (ch) {
     // export default ...

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -63,11 +63,11 @@ export function parse (_source, _name = '@') {
     imports.push({ t, n, s, e, ss, se, d, a, at: at.length > 0 ? at : null });
   }
   while (asm.re()) {
-    const s = asm.es(), e = asm.ee(), ls = asm.els(), le = asm.ele();
+    const s = asm.es(), e = asm.ee(), ls = asm.els(), le = asm.ele(), ss = asm.ess();
     const n = decodeIfQuoted(s, e);
     const ln = ls < 0 ? undefined : decodeIfQuoted(ls, le);
     exports.push({
-      s, e, ls, le,
+      s, e, ls, le, ss,
       n, ln,
     });
   }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -568,8 +568,13 @@ void tryParseExportStatement () {
 
   char16_t ch = commentWhitespace(true);
 
+  // Only commit the statement start once this is a real export: skipExpression
+  // re-enters here for an `export`-prefixed identifier (e.g. `exports`) in an
+  // initializer, which would otherwise clobber the start for later bindings.
   if (pos == curPos && !isPunctuator(ch))
     return;
+
+  export_statement_start = sStartPos;
 
   if (ch == '{') {
     pos++;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -70,6 +70,7 @@ struct Export {
   const char16_t* end;
   const char16_t* local_start;
   const char16_t* local_end;
+  const char16_t* statement_start;
   struct Export* next;
 };
 typedef struct Export Export;
@@ -81,6 +82,7 @@ Export* export_read_head = NULL;
 Import* import_write_head = NULL;
 Import* import_write_head_last = NULL;
 Export* export_write_head = NULL;
+const char16_t* export_statement_start = NULL;
 void* analysis_base;
 void* analysis_head;
 
@@ -167,6 +169,7 @@ void addExport (const char16_t* start, const char16_t* end, const char16_t* loca
   export->end = end;
   export->local_start = local_start;
   export->local_end = local_end;
+  export->statement_start = export_statement_start;
   export->next = NULL;
   hasModuleSyntax = true;
 }
@@ -228,6 +231,10 @@ int32_t els () {
 // getExportLocalEnd
 int32_t ele () {
   return export_read_head->local_end ? export_read_head->local_end - source : -1;
+}
+// getExportStatementStart
+uint32_t ess () {
+  return export_read_head->statement_start - source;
 }
 // readImport
 bool ri () {

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -195,6 +195,22 @@ export interface ExportSpecifier {
    * End of local name, or -1.
    */
   readonly le: number;
+
+  /**
+   * Start of the export statement.
+   *
+   * Only the statement start is provided; the statement end is not tracked
+   * (see https://github.com/guybedford/es-module-lexer/issues/112). Every
+   * specifier of a statement reports the same start, so `export { a, b }`
+   * returns the same `ss` for both `a` and `b`.
+   *
+   * @example
+   * const source = `export { a, b } from 'mod'`;
+   * const [imports, exports] = parse(source);
+   * source.slice(exports[0].ss, exports[0].ss + 6);
+   * // Returns "export"
+   */
+  readonly ss: number;
 }
 
 export interface ParseError extends Error {
@@ -250,11 +266,11 @@ export function parse (source: string, name = '@'): readonly [
     imports.push({ n, t, s, e, ss, se, d, a, at: at.length > 0 ? at : null });
   }
   while (wasm.re()) {
-    const s = wasm.es(), e = wasm.ee(), ls = wasm.els(), le = wasm.ele();
+    const s = wasm.es(), e = wasm.ee(), ls = wasm.els(), le = wasm.ele(), ss = wasm.ess();
     const n = decodeIfQuoted(source.slice(s, e));
     const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le));
     exports.push({
-      s, e, ls, le,
+      s, e, ls, le, ss,
       n, ln,
     });
   }
@@ -311,6 +327,8 @@ let wasm: {
   els(): number;
   /** getExportStart */
   es(): number;
+  /** getExportStatementStart */
+  ess(): number;
   /** facade */
   f(): boolean;
   /** hasModuleSyntax */

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -1258,6 +1258,37 @@ function x() {
     assertExportIs(source, exports[1], { n: 'yy', ln: undefined });
   });
 
+  test('Export statement start', () => {
+    const source = [
+      `export const x = 1;`,
+      `export function fn () {}`,
+      `export class C {}`,
+      `export default 42;`,
+      `export { c, d };`,
+      `export * as ns from './mod';`,
+      `export { e, f as g } from './re';`
+    ].join('\n');
+    const [, exports] = parse(source);
+    assert.strictEqual(exports.length, 9);
+
+    for (const expt of exports)
+      assert.strictEqual(source.slice(expt.ss, expt.ss + 6), 'export');
+
+    // Each specifier reports its statement's start, so the `{ c, d }` names and
+    // the re-exported `e` / `g` each share one `ss`.
+    assert.strictEqual(exports[0].ss, 0);
+    assert.strictEqual(exports[4].ss, exports[5].ss);
+    assert.strictEqual(exports[4].ss, source.indexOf('export { c, d }'));
+    assert.strictEqual(exports[7].ss, exports[8].ss);
+    assert.strictEqual(exports[7].ss, source.indexOf('export { e, f as g }'));
+
+    // Distinct statements resolve to their own offset, not a shared constant.
+    assert.strictEqual(exports[1].ss, source.indexOf('export function'));
+    assert.strictEqual(exports[2].ss, source.indexOf('export class'));
+    assert.strictEqual(exports[3].ss, source.indexOf('export default'));
+    assert.strictEqual(exports[6].ss, source.indexOf('export * as'));
+  });
+
   suite('Import From', () => {
     if (!js)
     test('non-identifier-string as (doubleQuote)', () => {


### PR DESCRIPTION
## Summary

Exports exposed only the exported and local name ranges, so a consumer could not locate the `export` keyword that introduces a binding. Each export specifier now carries `ss`, the statement start, matching the existing import `ss` — across the WASM, asm.js, and pure-JS readers. Only the statement start is tracked, not its end. Every specifier of one statement reports the same `ss`, so `export { a, b }` returns the same offset for both bindings.

## Test plan

- [ ] `chomp test` (wasm + asm.js): new "Export statement start" test covers named, default, declaration, re-export, and `export *` forms; each `ss` points at the introducing `export` keyword.

Fixes: https://github.com/guybedford/es-module-lexer/issues/112