### PR TITLE
fix: don't treat a method named `import` with 2+ args as a dynamic import

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -162,7 +162,8 @@ export function parse (_source, _name) {
         // dynamic import followed by { is not a dynamic import (so remove)
         // this is a sneaky way to get around { import () {} } v { import () }
         // block / object ambiguity without a parser (assuming source is valid)
-        if (source.charCodeAt(lastTokenPos) === 41/*)*/ && imports.length && imports[imports.length - 1].e === lastTokenPos) {
+        // se marks the closing paren; e is moved before the first comma for import(a, b)
+        if (source.charCodeAt(lastTokenPos) === 41/*)*/ && imports.length && imports[imports.length - 1].se === lastTokenPos) {
           imports.pop();
         }
         openClassPosStack[openTokenDepth] = nextBraceIsClass;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -164,7 +164,9 @@ bool parse () {
         // dynamic import followed by { is not a dynamic import (so remove)
         // this is a sneaky way to get around { import () {} } v { import () }
         // block / object ambiguity without a parser (assuming source is valid)
-        if (*lastTokenPos == ')' && import_write_head && import_write_head->end == lastTokenPos) {
+        // statement_end (the char after the closing paren) identifies that paren;
+        // end is moved before the first comma for import(a, b), so it can't be used here
+        if (*lastTokenPos == ')' && import_write_head && import_write_head->statement_end == lastTokenPos + 1) {
           import_write_head = import_write_head_last;
           if (import_write_head)
             import_write_head->next = NULL;

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -435,6 +435,48 @@ suite('Lexer', () => {
     assert.strictEqual(parse('import(`./a\nb.js`)')[0][0].n, './a\nb.js');
   });
 
+  test(`Method named import is not a dynamic import`, () => {
+    // A class/object method or shorthand named `import` with 2+ params was
+    // misreported as a dynamic import: the `)`-then-`{` guard used the wrong
+    // offset once a comma moved the recorded end.
+    const methodSources = [
+      'class C { import(a, b) {} }',
+      'class C { async import(keys, values) {} }',
+      'class C { static import(a, b) {} }',
+      'class C { import(a, b, c) {} }',
+      'class C { *import(a, b) {} }',
+      'class C { async *import(a, b) {} }',
+      'const o = { import(a, b) {} };',
+      'const o = { async import(a, b) {} };',
+      // shapes that already lexed correctly and must stay non-imports
+      'class C { import(a) {} }',
+      'class C { import() {} }',
+      'class C { get import() {} }',
+      'class C { set import(v) {} }',
+    ];
+    for (const source of methodSources) {
+      const [imports] = parse(source);
+      assert.strictEqual(imports.length, 0, `expected no imports for: ${source}`);
+    }
+  });
+
+  test(`Real dynamic import with options still detected`, () => {
+    // Regression guard for the method-name fix: genuine dynamic imports,
+    // including the two-argument import(specifier, options) form, must remain.
+    const dynamicSources = [
+      "import('x')",
+      'import(x)',
+      "import(x, { with: { type: 'json' } })",
+      "import('x', { with: { type: 'json' } })",
+      `import(foo, { type: 'json' })`,
+    ];
+    for (const source of dynamicSources) {
+      const [imports] = parse(source);
+      assert.strictEqual(imports.length, 1, `expected one import for: ${source}`);
+      assert.ok(imports[0].d >= 0, `expected dynamic import for: ${source}`);
+    }
+  });
+
   test(`Simple export destructuring`, () => {
     const source = `
       export const{URI,Utils,...Another}=LIB


### PR DESCRIPTION
A class/object method or shorthand named `import` with two or more parameters — e.g. `async import(a, b) {}` or `{ import(a, b) {} }` — is incorrectly reported as a dynamic import. Zero/one-arg forms and real dynamic imports are unaffected.

### Cause
On `import(`, a dynamic import is recorded and then removed when the `)` is immediately followed by `{` (the method case), via `import_write_head->end == lastTokenPos`. The `,` handler moves `->end` to just after the first argument, so with 2+ args `->end` no longer points at the closing `)`, the guard misfires, and the false positive survives. 0/1-arg forms have no comma to move `end`, which is why only 2+ args break.

### Fix

Fixes #208

Check `statement_end` (the char after the closing `)`, set regardless of commas) instead of the comma-mutated `end`. Mirrored the same change in the pure-JS `lexer.js`. Added unit tests for class/static/async/generator/object-shorthand methods named `import` with 2–3 args, plus a regression guard for `import(spec, options)`.

I haven't rebuilt the wasm/asm artifacts (no emsdk on hand) — the source change is verified against `test/_unit.cjs`.
