### PR TITLE
docs: correct stale limitations and gzip size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Outputs the list of exports and locations of import specifiers, including dynami
 
 Supports new syntax features including import attributes and source phase imports.
 
-A very small single JS file (~8KiB gzipped) that includes inlined Web Assembly for very fast source analysis of ECMAScript module syntax only.
+A very small single JS file (~7KiB gzipped) that includes inlined Web Assembly for very fast source analysis of ECMAScript module syntax only.
 
 For an example of the performance, Angular 1 (720KiB) is fully parsed in 5ms, in comparison to the fastest JS parser, Acorn which takes over 100ms.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Outputs the list of exports and locations of import specifiers, including dynami
 
 Supports new syntax features including import attributes and source phase imports.
 
-A very small single JS file (4KiB gzipped) that includes inlined Web Assembly for very fast source analysis of ECMAScript module syntax only.
+A very small single JS file (~8KiB gzipped) that includes inlined Web Assembly for very fast source analysis of ECMAScript module syntax only.
 
 For an example of the performance, Angular 1 (720KiB) is fully parsed in 5ms, in comparison to the fastest JS parser, Acorn which takes over 100ms.
 
@@ -271,17 +271,9 @@ Node.js 10+, and [all browsers with Web Assembly support](https://caniuse.com/#f
 
 The lexing approach is designed to deal with the full language grammar including RegEx / division operator ambiguity through backtracking and paren / brace tracking.
 
-The only limitation to the reduced parser is that the "exports" list may not correctly gather all export identifiers in the following edge cases:
+Because it lexes rather than fully parses, the analysis is not a validation pass: valid JS source is always analyzed correctly, but some invalid source is accepted without an error rather than rejected. For example `export const = 1` lexes to an empty exports list instead of throwing. Callers that need to reject invalid source should run a validating parser separately.
 
-```js
-// Only "a" is detected as an export, "q" isn't
-export var a = 'asdf', q = z;
-
-// "b" is not detected as an export
-export var { a: b } = asdf;
-```
-
-The above cases are handled gracefully in that the lexer will keep going fine, it will just not properly detect the export names above.
+Multiple exports per declaration (`export var a = 'asdf', q = z`) and renamed destructured exports (`export var { a: b } = asdf`) are detected correctly; earlier versions missed `q` and `b` in these forms.
 
 ### Benchmarks
 


### PR DESCRIPTION
## Summary

Two README claims no longer match the shipped library:

1. The **Limitations** section states that `export var a = 'asdf', q = z` only
   detects `a` (not `q`) and that `export var { a: b } = asdf` misses `b`. Both
   are detected correctly in current releases (verified against 2.2.0):

   ```js
   parse("export var a = 'asdf', q = z;")  // exports: ["a", "q"]
   parse("export var { a: b } = asdf;")    // exports: ["b"]
   ```

   The examples are replaced with the limitation that actually holds: the lexer
   does not validate, so some invalid source (e.g. `export const = 1`) is
   accepted without an error rather than rejected. This is already implied under
   "Grammar Support" ("may parse invalid JS source without errors"); the
   Limitations section now states it directly.

2. The **"4KiB gzipped"** figure is about half the current size. All three
   published builds gzip to ~8 KiB:

   | file | raw | gzip |
   | --- | --- | --- |
   | `dist/lexer.js` | 17132 | 7916 |
   | `dist/lexer.cjs` | 17211 | 7922 |
   | `dist/lexer.asm.js` | 27338 | 7741 |

No code changes; docs only.