### PR TITLE
feat: add CommonJS entry for es-module-lexer/js

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ For a version that works with CSP eval disabled, use the `es-module-lexer/js` bu
 import { parse } from 'es-module-lexer/js';
 ```
 
+CommonJS is also supported:
+
+```js
+const { parse } = require('es-module-lexer/js');
+```
+
+Like the main entry point, the asm.js build is synchronous, so there is no `init` to await.
+
 Instead of Web Assembly, this uses an asm.js build which is almost as fast as the Wasm version ([see benchmarks below](#benchmarks)).
 
 ### Import Attributes

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -10,7 +10,7 @@ WABT_PATH = '../wabt'
 
 [[task]]
 name = 'build'
-deps = ['dist/lexer.js', 'dist/lexer.cjs', 'dist/lexer.asm.js', 'types/lexer.d.ts']
+deps = ['dist/lexer.js', 'dist/lexer.cjs', 'dist/lexer.asm.core.cjs', 'dist/lexer.asm.js', 'dist/lexer.asm.cjs', 'types/lexer.d.ts']
 
 [[task]]
 name = 'bench'
@@ -29,14 +29,31 @@ deps = ['dist/lexer.js']
 env = { BENCH = 'wasm' }
 run = 'node --expose-gc bench/index.js'
 
+# The CSP-safe asm.js payload. Emitted once as a side-effecting script that
+# publishes `parse` on a shared realm-global (see src/lexer.asm.js). Both the
+# ESM (dist/lexer.asm.js) and CJS (dist/lexer.asm.cjs) `es-module-lexer/js`
+# entry points are thin wrappers over this single file, so the ~22KB payload is
+# never duplicated. It has no import/export, so the same bytes are valid under
+# both module systems; the .cjs extension makes `require` treat it as CommonJS.
 [[task]]
-target = 'dist/lexer.asm.js'
+target = 'dist/lexer.asm.core.cjs'
 dep = 'lib/lexer.asm.js'
 template = 'terser'
 [task.template-options]
-module = true
 compress = { ecma = 6, unsafe = true }
 output = { preamble = '/* es-module-lexer #PJSON_VERSION */' }
+
+# The `es-module-lexer/js` entry-point wrappers are committed as source (they
+# never contain the payload) and copied verbatim into dist/ next to the core.
+[[task]]
+target = 'dist/lexer.asm.js'
+deps = ['src/lexer.asm.wrapper.js', 'dist/lexer.asm.core.cjs']
+run = 'cp src/lexer.asm.wrapper.js $TARGET'
+
+[[task]]
+target = 'dist/lexer.asm.cjs'
+deps = ['src/lexer.asm.wrapper.cjs', 'dist/lexer.asm.core.cjs']
+run = 'cp src/lexer.asm.wrapper.cjs $TARGET'
 
 [[task]]
 target = 'dist/lexer.cjs'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     },
     "./js": {
       "types": "./types/lexer.d.ts",
-      "default": "./dist/lexer.asm.js"
+      "import": "./dist/lexer.asm.js",
+      "require": "./dist/lexer.asm.cjs"
     }
   },
   "scripts": {

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -20,7 +20,7 @@ const copy = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1 ? function (sr
 const words = '{{WORDS}}';
 
 let source, name;
-export function parse (_source, _name = '@') {
+function parse (_source, _name = '@') {
   source = _source;
   name = _name;
   // 2 bytes per string code point
@@ -229,5 +229,12 @@ function isBr (c) {
 function syntaxError () {
   throw Object.assign(new Error(`Parse error ${name}:${source.slice(0, acornPos).split('\n').length}:${acornPos - source.lastIndexOf('\n', acornPos - 1)}`), { idx: acornPos });
 }
+
+// This file is emitted as a single side-effecting script (dist/lexer.asm.core.cjs)
+// that is loaded by both the ESM and CJS `es-module-lexer/js` wrappers, so the
+// heavy asm.js payload only ships once. Instead of exporting, publish `parse`
+// on a shared realm-global keyed by a well-known symbol; the wrappers read it
+// back and re-expose it under their respective module systems.
+(typeof globalThis !== 'undefined' ? globalThis : self)[Symbol.for('es-module-lexer/js')] = { parse };
 
 // function asmInit () { ... } from lib/lexer.asm.js is concatenated at the end here

--- a/src/lexer.asm.wrapper.cjs
+++ b/src/lexer.asm.wrapper.cjs
@@ -1,0 +1,9 @@
+// CJS wrapper for the CSP-safe asm.js build (`es-module-lexer/js`).
+//
+// The asm.js payload is loaded once as a side-effecting script that publishes
+// its API on a shared realm-global (see src/lexer.asm.js). This wrapper simply
+// re-exports it, so the ~22KB payload is not duplicated across the ESM and CJS
+// entry points.
+require('./lexer.asm.core.cjs');
+
+module.exports = globalThis[Symbol.for('es-module-lexer/js')];

--- a/src/lexer.asm.wrapper.js
+++ b/src/lexer.asm.wrapper.js
@@ -1,0 +1,9 @@
+// ESM wrapper for the CSP-safe asm.js build (`es-module-lexer/js`).
+//
+// The asm.js payload is loaded once as a side-effecting script that publishes
+// its API on a shared realm-global (see src/lexer.asm.js). This wrapper simply
+// re-exports it, so the ~22KB payload is not duplicated across the ESM and CJS
+// entry points.
+import './lexer.asm.core.cjs';
+
+export const parse = globalThis[Symbol.for('es-module-lexer/js')].parse;


### PR DESCRIPTION
## Summary

The `es-module-lexer/js` (CSP-safe asm.js) build shipped ESM only, so `require('es-module-lexer/js')` failed. The obvious fix — transpiling the ESM output to CJS with babel, as the Wasm build does — would duplicate the ~22KB asm.js payload into a second file.

Instead the payload is emitted once as a side-effecting script (`dist/lexer.asm.core.cjs`) that publishes `parse` on a shared realm-global keyed by `Symbol.for('es-module-lexer/js')`. The ESM and CJS entry points are thin wrappers (committed under `src/`) that load the core for its side effect and re-expose the symbol. The core has no import/export, so the same bytes are valid under both module systems; the `.cjs` extension makes `require` treat it as CommonJS.

## Why

Adding `require` support should not double the on-disk footprint of the CSP build. The wrapper indirection keeps the payload single-copy: both entry points share one `parse` (same function identity), so there is no size regression versus the ESM-only status quo.

## Test plan

- [ ] `chomp build` produces `dist/lexer.asm.core.cjs` plus the two wrappers, and the wrappers stay tiny (no payload).
- [ ] `chomp test` (asm + wasm suites) pass.
- [ ] `import { parse } from 'es-module-lexer/js'` and `require('es-module-lexer/js')` both expose the same `parse`.