### PR TITLE
fix: allow wasm memory growth for sources over ~4MB

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -102,7 +102,7 @@ run = """
 
 	${{ EMSDK_PATH }}/upstream/emscripten/emcc src/lexer.c -o lib/lexer.wasm -Oz -flto --no-entry -s STANDALONE_WASM=1 \
 	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','_ess','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','___heap_base']" \
-	-s SUPPORT_LONGJMP=0 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
+	-s SUPPORT_LONGJMP=0 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
 """
 
 [[task]]

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -2051,4 +2051,13 @@ export { d as a, p as b, z as c, r as d, q }`;
       assert.strictEqual(err.idx, 11);
     }
   });
+
+  test('Large source', () => {
+    const source = `import 'a';\nconst x = "${'a'.repeat(5 * 1024 * 1024)}";\nexport { x }`;
+    const [imports, exports] = parse(source);
+    assert.strictEqual(imports.length, 1);
+    assert.strictEqual(imports[0].n, 'a');
+    assert.strictEqual(exports.length, 1);
+    assert.strictEqual(exports[0].n, 'x');
+  });
 });


### PR DESCRIPTION
Fixes #214.

## Root cause

The emsdk toolchain update in #203 (shipped in 2.2.0) regressed the wasm memory declaration. The old fastcomp build emitted growable memory (min 1 page, no maximum), but the upstream emscripten build defaults to fixed-size memory:

| Build | flags | initial | maximum |
|---|---|---|---|
| 2.1.0 | `0x0` | 1 page | none (growable to 4 GiB engine cap) |
| 2.2.0 | `0x1` | 258 pages (~16 MiB) | **258 pages (~16 MiB)** |

With `maximum == initial`, the unconditional `memory.grow()` in `parse()` throws `WebAssembly.Memory.grow(): Maximum memory size exceeded` for any source that doesn't fit the initial 16 MiB. Since the source is copied in as UTF-16 (`4 * (len + 1)` bytes), that's the ~4M char threshold reported in the issue. The asm.js build was unaffected.

## Fix

Add `-s ALLOW_MEMORY_GROWTH=1` to the emcc build, restoring growable memory (max 32768 pages / 2 GiB, emscripten's default ceiling — ~512M chars of source).

The issue repro now passes against the rebuilt `dist/lexer.js`:

```js
import { parse, init } from 'es-module-lexer';
await init;
const big = 'const x = "' + 'a'.repeat(5 * 1024 * 1024) + '";\n';
parse(big); // OK (previously threw)
```

Also adds a 5MB large-source regression test, verified to fail against a fresh build off main and pass with this change; `chomp test` passes (149 tests, wasm + asm).
