### PR TITLE
fix: allow wasm memory growth in the minimal build, document minimal build

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,27 @@ import { parse } from 'es-module-lexer/js';
 
 Instead of Web Assembly, this uses an asm.js build which is almost as fast as the Wasm version ([see benchmarks below](#benchmarks)).
 
+### Minimal Build
+
+For size-sensitive embedders, the `es-module-lexer/minimal` build drops certain features to reduce the binary size. This is used for example by [es-module-shims](https://github.com/guybedford/es-module-shims):
+
+```js
+import { parse } from 'es-module-lexer/minimal';
+```
+
+Compared to the full build:
+
+* `parse` returns a two-element `[imports, exports]` tuple only - the third and fourth facade and `hasModuleSyntax` booleans are dropped.
+* Imports drop the parsed attribute list `at` (the attribute source remains recoverable via the `a` attributes index).
+* Exports drop the statement start `ss`.
+
+All other fields are identical to the full build. For CSP eval disabled support, the equivalent asm.js build is available as `es-module-lexer/minimal/js`.
+
 ### Import Attributes
 
 The `a` field provides the index of the start of the `{` attributes bracket, or -1 for no attributes.
 
-The list of attribute key and value pairs are provided on the `at` field:
+The list of attribute key and value pairs are provided on the `at` field (full build only):
 
 ```js
 const [imports] = parse(`
@@ -225,7 +241,7 @@ For dynamic import expressions, this field will be empty if not a valid JS strin
 
 ### Facade Detection
 
-Facade modules that only use import / export syntax can be detected via the third return value:
+Facade modules that only use import / export syntax can be detected via the third return value (full build only):
 
 ```js
 const [,, facade] = parse(`
@@ -239,7 +255,7 @@ facade === true;
 
 ### ESM Detection
 
-Modules that uses ESM syntaxes can be detected via the fourth return value:
+Modules that uses ESM syntaxes can be detected via the fourth return value (full build only):
 
 ```js
 const [,,, hasModuleSyntax] = parse(`

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -143,7 +143,7 @@ run = """
 
 [[task]]
 # Minimal wasm build (-DLEXER_MIN): drops the getters es-module-shims never
-# reads (ip/ess/f/ms + attributes) and the facade fast path. See src/lexer.c.
+# reads (ess/f/ms + attributes) and the facade fast path. See src/lexer.c.
 # Depends on lib/lexer.wasm so the two upstream-emsdk builds run sequentially
 # rather than racing on the shared emsdk activation.
 target = 'lib/lexer.min.wasm'
@@ -155,7 +155,7 @@ run = """
 
 	${{ EMSDK_PATH }}/upstream/emscripten/emcc src/lexer.c -DLEXER_MIN -o lib/lexer.min.wasm -Oz -flto --no-entry -s STANDALONE_WASM=1 \
 	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','___heap_base']" \
-	-s SUPPORT_LONGJMP=0 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
+	-s SUPPORT_LONGJMP=0 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
 """
 
 [[task]]

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -2,8 +2,8 @@ const assert = require('assert');
 
 let js = false;
 // The minimal builds (MINIMAL=1) drop the fields es-module-shims never reads:
-// dynamic-import `n`, the parsed attribute list `at`, and export `ss`. Tests
-// asserting on those are gated behind `!min`.
+// the parsed attribute list `at`, export `ss`, and the facade/hasModuleSyntax
+// flags. Tests asserting on those are gated behind `!min`.
 const min = !!process.env.MINIMAL;
 let parse;
 const init = (async () => {


### PR DESCRIPTION
The minimal wasm build added in #211 predates #217's memory growth fix, so `lib/lexer.min.wasm` was built without `-s ALLOW_MEMORY_GROWTH=1` and has the same fixed 258-page (~16 MiB) memory — `parse()` on sources over ~4M chars throws `WebAssembly.Memory.grow(): Maximum memory size exceeded` (#214). The `Large source` test from #217 catches this on main under `test:minimal:wasm`.

## Changes

- Add `-s ALLOW_MEMORY_GROWTH=1` to the `lib/lexer.min.wasm` build task, matching the full build. Verified before/after: memory section goes from `max = 258 pages` to `max = 32768 pages (2 GiB)`, and the `Large source` test goes from failing to passing under `MINIMAL=1 WASM=1`.
- Document the `es-module-lexer/minimal` / `es-module-lexer/minimal/js` builds in the readme.
- Correct stale #211 comments in `chompfile.toml` and `test/_unit.cjs` claiming the minimal build drops dynamic-import `n` / `ip()` — `_ip` is exported and read (verified at runtime: `import('dyn')` reports `n: 'dyn'`); only `at`, export `ss`, and the facade/`hasModuleSyntax` flags are dropped.

`chomp test` passes: 148 tests across all four build variants (wasm, asm, minimal wasm, minimal asm).