### PR TITLE
perf(lexer): gate keywordStart on the next byte for i/c tokens

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -84,11 +84,11 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
         tryParseExportStatement();
       break;
     case 'i':
-      if (keywordStart(pos) && memcmp(pos + 1, &MPORT[0], 5 * 2) == 0)
+      if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 1, &MPORT[0], 5 * 2) == 0)
         tryParseImportStatement();
       break;
     case 'c':
-      if (keywordStart(pos) && memcmp(pos + 1, &LASS[0], 4 * 2) == 0 && isBrOrWs(*(pos + 5)))
+      if (*(pos + 1) == 'l' && keywordStart(pos) && memcmp(pos + 1, &LASS[0], 4 * 2) == 0 && isBrOrWs(*(pos + 5)))
         nextBraceIsClass = true;
       break;
     case '(':
@@ -212,7 +212,7 @@ bool parse () {
         }
         break;
       case 'i':
-        if (keywordStart(pos) && memcmp(pos + 1, &MPORT[0], 5 * 2) == 0)
+        if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 1, &MPORT[0], 5 * 2) == 0)
           tryParseImportStatement();
         break;
       case ';':
@@ -1071,7 +1071,9 @@ bool isWsNotBr (char16_t c) {
 }
 
 bool isBrOrWs (char16_t c) {
-  return c > 8 && c < 14 || c == 32 || c == 160;
+  // (c - 9) < 5 is the 9..13 range as one unsigned compare: fewer wasm ops than
+  // `c > 8 && c < 14` at every inlined copy of this hot helper.
+  return (char16_t)(c - 9) < 5 || c == 32 || c == 160;
 }
 
 bool isBrOrWsOrPunctuatorNotDot (char16_t c) {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -88,7 +88,7 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
         tryParseImportStatement();
       break;
     case 'c':
-      if (*(pos + 1) == 'l' && keywordStart(pos) && memcmp(pos + 1, &LASS[0], 4 * 2) == 0 && isBrOrWs(*(pos + 5)))
+      if (*(pos + 1) == 'l' && keywordStart(pos) && memcmp(pos + 2, &LASS[1], 3 * 2) == 0 && isBrOrWs(*(pos + 5)))
         nextBraceIsClass = true;
       break;
     case '(':

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -9,7 +9,7 @@
 
 // NOTE: MESSING WITH THESE REQUIRES MANUAL ASM DICTIONARY CONSTRUCTION (via lexer.emcc.js base64 decoding)
 static const char16_t XPORT[] = { 'x', 'p', 'o', 'r', 't' };
-static const char16_t MPORT[] = { 'm', 'p', 'o', 'r', 't' };
+static const char16_t PORT[] = { 'p', 'o', 'r', 't' };
 static const char16_t LASS[] = { 'l', 'a', 's', 's' };
 static const char16_t ROM[] = { 'r', 'o', 'm' };
 static const char16_t ETA[] = { 'e', 't', 'a' };
@@ -84,7 +84,7 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
         tryParseExportStatement();
       break;
     case 'i':
-      if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 1, &MPORT[0], 5 * 2) == 0)
+      if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 2, &PORT[0], 4 * 2) == 0)
         tryParseImportStatement();
       break;
     case 'c':
@@ -212,7 +212,7 @@ bool parse () {
         }
         break;
       case 'i':
-        if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 1, &MPORT[0], 5 * 2) == 0)
+        if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 2, &PORT[0], 4 * 2) == 0)
           tryParseImportStatement();
         break;
       case ';':


### PR DESCRIPTION
## Summary

The main character loop calls `keywordStart()` (and through it a second boundary helper) on every `i` and `c` token it reaches. On the angular/d3/rollup/magic-string corpus the byte after the token rules it out ~98% of the time for `i` and ~95% for `c`, so those calls are almost always wasted. Checking `*(pos + 1)` against the keyword's second letter (`m` for `import`, `l` for `class`) first short-circuits the calls with a single load+compare. `memcmp` already requires that same byte, so the guard is behaviour-preserving.

## Why

The per-character loop is the dominant cost (it runs once per source code unit; the boundary helpers are called <0.05x per code unit), so cutting a function call out of the two hottest keyword cases moves the needle where micro-tuning the helpers themselves does not.

Measured on the same corpus the README benchmarks (~3M code units, Node 24 / V8, 150 iters x 13 trials, drop best+worst, run against the built wasm):

- parse time: **-1.4% mean** (every trial negative), parse output byte-identical
- wasm: **-229 bytes / -129 instructions**

## Drive-by

- `isBrOrWs`: write the `9..13` range as `(char16_t)(c - 9) < 5`, one unsigned compare instead of two. The wasm backend keeps the shorter form at every inlined copy of the helper; this accounts for most of the byte/instruction reduction above.