### PR TITLE
perf(lexer): skip identifier and number runs

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -70,6 +70,12 @@ static inline __attribute__((always_inline)) bool handleSlash () {
   return false;
 }
 
+static inline __attribute__((always_inline)) bool isTokenRunChar (char16_t ch) {
+  // Fold ASCII case; NBSP is the only non-ASCII whitespace recognized here.
+  return (char16_t)((ch | 32) - 'a') < 26 || (char16_t)(ch - '0') < 10 ||
+    ch == '$' || ch == '_' || ch == '\\' || (ch > 127 && ch != 160);
+}
+
 // Consume one token at the current ch/pos, updating the global tokenizer state.
 // The single source of tokenization: the main loop and skipExpression both call
 // it, so the regex/keyword/import rules never diverge. Comments do not advance
@@ -80,17 +86,21 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
   bool isComment = false;
   switch (ch) {
     case 'e':
-      if (openTokenDepth == 0 && keywordStart(pos) && memcmp(pos + 1, &XPORT[0], 5 * 2) == 0)
+      if (openTokenDepth == 0 && keywordStart(pos) && memcmp(pos + 1, &XPORT[0], 5 * 2) == 0) {
         tryParseExportStatement();
-      break;
+        break;
+      }
+      goto skipTokenRun;
     case 'i':
-      if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 2, &PORT[0], 4 * 2) == 0)
+      if (*(pos + 1) == 'm' && keywordStart(pos) && memcmp(pos + 2, &PORT[0], 4 * 2) == 0) {
         tryParseImportStatement();
-      break;
+        break;
+      }
+      goto skipTokenRun;
     case 'c':
       if (*(pos + 1) == 'l' && keywordStart(pos) && memcmp(pos + 2, &LASS[1], 3 * 2) == 0 && isBrOrWs(*(pos + 5)))
         nextBraceIsClass = true;
-      break;
+      goto skipTokenRun;
     case '(':
       openTokenStack[openTokenDepth].token = AnyParen;
       openTokenStack[openTokenDepth++].pos = lastTokenPos;
@@ -160,6 +170,12 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
       openTokenStack[openTokenDepth++].token = Template;
       templateString();
       break;
+    default:
+      if (!isTokenRunChar(ch))
+        break;
+    skipTokenRun:
+      while (isTokenRunChar(*(++pos)));
+      pos--;
   }
   if (!isComment)
     lastTokenPos = pos;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -174,8 +174,7 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
       if (!isTokenRunChar(ch))
         break;
     skipTokenRun:
-      while (isTokenRunChar(*(++pos)));
-      pos--;
+      while (isTokenRunChar(*(pos + 1))) pos++;
   }
   if (!isComment)
     lastTokenPos = pos;

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -841,6 +841,24 @@ suite('Lexer', () => {
     `);
   });
 
+  test('Identifier runs preserve template and punctuation boundaries', () => {
+    const source = `
+      const tag = String.raw;
+      const extraordinarilyLongIdentifier = 6;
+      const \\u0065scapedIdentifier = extraordinarilyLongIdentifier / 2;
+      const templateResult = tag\`value \${import('template-edge')}\`;
+      class LongClassName {
+        #privateField = import('class-edge');
+        method () { return /import\\('ignored'\\)/.test(''); }
+      }
+      \u00a0import('nbsp-edge');
+      export { templateResult, LongClassName };
+    `;
+    const [imports, exports] = parse(source);
+    assert.deepStrictEqual(imports.map(impt => impt.n), ['template-edge', 'class-edge', 'nbsp-edge']);
+    assert.deepStrictEqual(exports.map(expt => expt.n), ['templateResult', 'LongClassName']);
+  });
+
   test('Division operator case', () => {
     parse(`
       function log(r){


### PR DESCRIPTION
## Summary

Skip the remainder of identifier and number runs after their first token dispatch, avoiding repeated switch dispatch and `lastTokenPos` stores.

On the 3,057 KiB sample corpus, Wasm improves from 15,356.31 to 13,010.46 us per sweep on Node 18.20.8 (-15.28%) and from 11,724.34 to 9,856.69 us on Node 24.18.0 (-15.93%). The asm.js build improves from 15,934.34 to 12,945.57 us on Node 24.18.0 (-18.76%). The full Wasm binary grows by 379 raw / 105 gzip bytes.

## Test plan

- [x] Run the full Wasm and asm.js test matrix, including minimal builds
- [x] Compare baseline and candidate metadata over 100,000 generated sources