### PR TITLE
Fix parsing of `export abstract class` syntax

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -355,8 +355,22 @@ function tryParseExportStatement () {
       addExport(pos, pos + 7, -1, -1);
       return;
 
-    // export async? function*? name () {
     case 97/*a*/:
+      // export abstract class name ...
+      if (source.startsWith('bstract', pos + 1) && isWsNotBr(source.charCodeAt(pos + 8))) {
+        pos += 8;
+        ch = commentWhitespace(true);
+        if (ch === 99/*c*/ && source.startsWith('lass', pos + 1) && isBrOrWsOrPunctuatorNotDot(source.charCodeAt(pos + 5))) {
+          pos += 5;
+          ch = commentWhitespace(true);
+          const startPos = pos;
+          ch = readToWsOrPunctuator(ch);
+          addExport(startPos, pos, startPos, pos);
+          pos--;
+        }
+        return;
+      }
+    // export async? function*? name () {
       pos += 5;
       commentWhitespace(true);
     // fallthrough

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -31,6 +31,7 @@ static const char16_t ELS[] = { 'e', 'l', 's' };
 static const char16_t BREA[] = { 'b', 'r', 'e', 'a' };
 static const char16_t CONTIN[] = { 'c', 'o', 'n', 't', 'i', 'n' };
 static const char16_t SYNC[] = {'s', 'y', 'n', 'c'};
+static const char16_t BSTRACT[] = {'b', 's', 't', 'r', 'a', 'c', 't'};
 static const char16_t UNCTION[] = {'u', 'n', 'c', 't', 'i', 'o', 'n'};
 static const char16_t OURCE[] = {'o', 'u', 'r', 'c', 'e'};
 static const char16_t EFER[] = {'e', 'f', 'e', 'r'};
@@ -715,8 +716,22 @@ void tryParseExportStatement () {
         pos = (char16_t*)(startPos + 6);
         return;
       }
-      // export async? function*? name () {
       case 'a':
+        // export abstract class name ...
+        if (memcmp(pos + 1, &BSTRACT[0], 7 * 2) == 0 && isWsNotBr(*(pos + 8))) {
+          pos += 8;
+          ch = commentWhitespace(true);
+          if (ch == 'c' && memcmp(pos + 1, &LASS[0], 4 * 2) == 0 && isBrOrWsOrPunctuatorNotDot(*(pos + 5))) {
+            pos += 5;
+            ch = commentWhitespace(true);
+            const char16_t* startPos = pos;
+            ch = readToWsOrPunctuator(ch);
+            addExport(startPos, pos, startPos, pos);
+            pos--;
+          }
+          return;
+        }
+      // export async? function*? name () {
         pos += 5;
         commentWhitespace(false);
       // fallthrough

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -965,6 +965,21 @@ suite('Lexer', () => {
     assertExportIs(source, exports[1], {n: 'Q', ln: 'Q' });
   });
 
+  test('Exported abstract class (TypeScript)', () => {
+    const source = `
+      export abstract class Foo {
+        abstract bar (): void;
+      }
+      export abstract class Baz extends Qux {}
+      export class Plain {}
+    `;
+    const [, exports] = parse(source);
+    assert.strictEqual(exports.length, 3);
+    assertExportIs(source, exports[0], { n: 'Foo', ln: 'Foo' });
+    assertExportIs(source, exports[1], { n: 'Baz', ln: 'Baz' });
+    assertExportIs(source, exports[2], { n: 'Plain', ln: 'Plain' });
+  });
+
   test('Export destructuring', () => {
     const source = `
       export const { a, b } = foo;


### PR DESCRIPTION
The current logic in `lexer.c` mis-parses code like `export abstract class Foo {}`, which we started observing in our builds when [import-in-the-middle@3.3.0](https://github.com/nodejs/import-in-the-middle/blob/main/CHANGELOG.md#330-2026-07-02) recently began parsing `.ts` files using this library.  This fix should resolve the issue by adding specific handling for the required syntax