### PR TITLE
fix: annotate asm.js integer return type

### DIFF
--- a/build/combine-asm.mjs
+++ b/build/combine-asm.mjs
@@ -35,7 +35,7 @@ const replacements = [
 		a = a | 0;
 		b = b | 0;
 		v = a + b + 15 & -16;
-		return b;
+		return b | 0;
 	}
 	return {
 		su,`],

--- a/test/asm-validation.cjs
+++ b/test/asm-validation.cjs
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { resolve } = require('path');
+const { pathToFileURL } = require('url');
+
+if (process.env.ASM) {
+  const min = !!process.env.MINIMAL;
+
+  suite('asm.js', () => {
+    test('validates without falling back to JavaScript', () => {
+      const bundle = pathToFileURL(resolve(
+        __dirname,
+        min ? '../dist/lexer.minimal.asm.js' : '../dist/lexer.asm.js'
+      )).href;
+      const env = { ...process.env };
+      delete env.NODE_NO_WARNINGS;
+      delete env.NODE_OPTIONS;
+
+      // Invalid asm.js remains valid JavaScript, so V8 otherwise falls back
+      // successfully and the normal parser assertions cannot detect it.
+      const child = spawnSync(process.execPath, [
+        '--validate-asm',
+        '--no-suppress-asm-messages',
+        '--input-type=module',
+        '--eval',
+        `const { parse } = await import(${JSON.stringify(bundle)}); parse('export {}')`
+      ], { encoding: 'utf8', env });
+
+      if (child.error) throw child.error;
+      assert.strictEqual(child.status, 0, child.stderr || child.stdout);
+      assert.strictEqual(/Invalid asm\.js|Linking failure in asm\.js/.test(child.stderr), false, child.stderr);
+    });
+  });
+}


### PR DESCRIPTION
<details>
<summary>AI disclosure — Codex, GPT-5.6 Sol (Extra High)</summary>

This PR was researched, implemented, tested, and drafted by Codex. I provided the requirements, requested alignment with project conventions, and approved publication.

Codex was asked to:

- find the regression boundary and root cause
- preserve behavior with a minimal fix
- audit #203 for similar asm.js issues
- cover full and minimal builds
- prevent V8 fallback from hiding failures

Codex reviewed the build history, asm.js rules, and V8 behavior; changed `return b` to `return b | 0`; and added an explicit asm.js validation test.

Validation covered published versions 2.0.0–2.3.1, Node 16–25, full and minimal bundles, and behavior comparison across 20 source files. The complete `chomp test` matrix is pending CI approval.

</details>

## Summary

Since 2.2.0, invoking the `es-module-lexer/js` build under V8 emits:

```text
Invalid asm.js: Invalid return type
```

The bundle remains valid JavaScript, so V8 falls back to normal JavaScript compilation and parsing still succeeds. This allows the existing functional tests to pass while the asm.js module itself fails validation.

The regression was introduced by #203. Its injected allocator helper returns an integer parameter without the result coercion required by asm.js:

```js
function su(a, b) {
  a = a | 0;
  b = b | 0;
  v = a + b + 15 & -16;
  return b;
}
```

Returning `b` is the intended behavior; only its asm.js return type annotation is missing.

## Changes

- Change the allocator return to `return b | 0`
- Add a V8-specific regression test for both full and minimal asm.js builds
- Run validation in a child process with asm.js diagnostics enabled, so JavaScript fallback cannot hide validation or linking failures

The additional coercion does not change runtime behavior because `b` has already been converted with `b = b | 0`.

## Test plan

- [x] Confirm the regression test fails for the unmodified 2.3.1 full and minimal asm.js bundles
- [x] Confirm the test passes for the patched full and minimal bundles
- [x] Run JavaScript syntax and diff checks
- [ ] Run the complete `chomp test` matrix in CI with the Emscripten and Fastcomp toolchains
