### PR TITLE
chore: Node.js 18+ support, CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,14 @@ jobs:
           EMSDK_FASTCOMP_PATH: './emsdk-fastcomp'
         run: chomp test
 
+      - name: Legacy Browser Test (Firefox 67)
+        if: matrix.node == 18
+        run: |
+          sudo apt-get install -y libdbus-glib-1-2 libxt6 >/dev/null
+          curl -sL https://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/en-US/firefox-67.0.4.tar.bz2 | tar xj
+          curl -sL https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz | tar xz
+          FIREFOX_BIN=$PWD/firefox/firefox GECKODRIVER=$PWD/geckodriver node build/test-legacy-browser.mjs
+
       - name: Footprint
         env:
           EMSDK_PATH: './emsdk'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,18 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, latest]
 
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
 
       - name: Install Emscripten
         run: |

--- a/README.md
+++ b/README.md
@@ -350,7 +350,9 @@ hasModuleSyntax === false;
 
 ### Environment Support
 
-Node.js 18+, and [all browsers with Web Assembly support](https://caniuse.com/#feat=wasm).
+The full build requires Node.js 18+ and engines with [WebAssembly SIMD support](https://webassembly.org/features/) (Chrome 91+, Firefox 89+, Safari 16.4+).
+
+The minimal build (`es-module-lexer/minimal`) carries no SIMD requirement, running in [all browsers with WebAssembly support](https://caniuse.com/#feat=wasm), and the asm.js builds of both variants run in legacy browsers without WebAssembly — the es-module-shims use case.
 
 ### Grammar Support
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ hasModuleSyntax === false;
 
 The full build requires Node.js 18+ and engines with [WebAssembly SIMD support](https://webassembly.org/features/) (Chrome 91+, Firefox 89+, Safari 16.4+).
 
-The minimal build (`es-module-lexer/minimal`) carries no SIMD requirement, running in [all browsers with WebAssembly support](https://caniuse.com/#feat=wasm), and the asm.js builds of both variants run in legacy browsers without WebAssembly — the es-module-shims use case.
+The minimal build (`es-module-lexer/minimal`) carries no SIMD requirement, running in all browsers with baseline [ES modules support](https://caniuse.com/es6-module-dynamic-import) (Chrome 63+, Firefox 67+, Safari 11.1+ — the [es-module-shims](https://github.com/guybedford/es-module-shims) support matrix), with the asm.js builds covering those without WebAssembly.
 
 ### Grammar Support
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ hasModuleSyntax === false;
 
 ### Environment Support
 
-Node.js 10+, and [all browsers with Web Assembly support](https://caniuse.com/#feat=wasm).
+Node.js 18+, and [all browsers with Web Assembly support](https://caniuse.com/#feat=wasm).
 
 ### Grammar Support
 

--- a/build/check-no-simd.mjs
+++ b/build/check-no-simd.mjs
@@ -4,11 +4,17 @@ import initWabt from 'wabt';
 import { readFileSync } from 'node:fs';
 
 const file = process.env.WASM;
+// Plain copy: wabt mishandles Node's pooled Buffer views (a nonzero offset
+// into a shared ArrayBuffer), reading past the slice on newer Node versions.
+const bytes = new Uint8Array(readFileSync(file));
 const wabt = await initWabt();
 try {
-  wabt.readWasm(readFileSync(file), { simd: false });
+  wabt.readWasm(bytes, { simd: false });
 }
 catch {
+  // Only a clean parse with SIMD enabled proves the failure above meant SIMD
+  // instructions; a binary wabt cannot read at all throws through as-is.
+  wabt.readWasm(bytes, { simd: true });
   console.error(`${file}: contains SIMD instructions`);
   process.exit(1);
 }

--- a/build/test-legacy-browser.mjs
+++ b/build/test-legacy-browser.mjs
@@ -64,3 +64,5 @@ if (failure) {
   process.exit(1);
 }
 console.log('legacy browser test: PASS');
+// Open keep-alive sockets (driver, static server) must not hold the process.
+process.exit(0);

--- a/build/test-legacy-browser.mjs
+++ b/build/test-legacy-browser.mjs
@@ -1,0 +1,66 @@
+// Runs test/legacy.html in a legacy headless Firefox over raw WebDriver HTTP,
+// asserting the non-SIMD builds still parse there. FIREFOX_BIN and GECKODRIVER
+// point at the binaries (see the CI workflow's legacy step).
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { extname } from 'node:path';
+
+const MIME = { '.html': 'text/html', '.js': 'application/javascript', '.mjs': 'application/javascript' };
+const server = createServer(async (req, res) => {
+  try {
+    const path = req.url.split('?')[0];
+    const body = await readFile('.' + path);
+    res.writeHead(200, { 'content-type': MIME[extname(path)] || 'application/octet-stream' });
+    res.end(body);
+  }
+  catch {
+    res.writeHead(404);
+    res.end();
+  }
+});
+await new Promise(resolve => server.listen(8123, resolve));
+
+// A legacy Firefox content sandbox crashes on modern kernels; the smoke test
+// needs no isolation, so run single-process with the sandbox off.
+const driver = spawn(process.env.GECKODRIVER, ['--port', '4444'], {
+  stdio: 'inherit',
+  env: { ...process.env, MOZ_DISABLE_CONTENT_SANDBOX: '1', MOZ_FORCE_DISABLE_E10S: '1' }
+});
+await new Promise(resolve => setTimeout(resolve, 2000));
+
+const drive = async (path, body) => {
+  const res = await fetch('http://127.0.0.1:4444' + path, body === undefined
+    ? undefined
+    : { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+  const json = await res.json();
+  if (!res.ok)
+    throw new Error(`${path}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json.value;
+};
+
+let failure = null;
+try {
+  const session = await drive('/session', {
+    capabilities: { alwaysMatch: { 'moz:firefoxOptions': { binary: process.env.FIREFOX_BIN, args: ['-headless'] } } }
+  });
+  await drive(`/session/${session.sessionId}/url`, { url: 'http://127.0.0.1:8123/test/legacy.html' });
+  let title = 'RUNNING';
+  for (let i = 0; i < 30 && title === 'RUNNING'; i++) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    title = await drive(`/session/${session.sessionId}/title`);
+  }
+  if (title !== 'PASS')
+    failure = title === 'RUNNING' ? 'timed out' : title;
+  await drive(`/session/${session.sessionId}`, undefined).catch(() => {});
+}
+catch (err) {
+  failure = err.message;
+}
+driver.kill();
+server.close();
+if (failure) {
+  console.error(`legacy browser test: ${failure}`);
+  process.exit(1);
+}
+console.log('legacy browser test: PASS');

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -154,6 +154,7 @@ run = """
 	${{ EMSDK_PATH }}/emsdk activate 6.0.0
 
 	${{ EMSDK_PATH }}/upstream/emscripten/emcc src/lexer.c -DLEXER_MIN -o lib/lexer.min.wasm -Oz -flto --no-entry -s STANDALONE_WASM=1 \
+	-mno-bulk-memory -mno-reference-types -mno-multivalue -mno-sign-ext -mno-nontrapping-fptoint \
 	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_es','_ee','_els','_ele','___heap_base']" \
 	-s SUPPORT_LONGJMP=0 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "es-module-lexer",
   "version": "2.3.1",
   "description": "Lexes ES modules returning their import/export metadata",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "main": "dist/lexer.cjs",
   "module": "dist/lexer.js",
   "types": "types/lexer.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "es-module-lexer",
   "version": "2.3.1",
   "description": "Lexes ES modules returning their import/export metadata",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "main": "dist/lexer.cjs",
   "module": "dist/lexer.js",
   "types": "types/lexer.d.ts",

--- a/test/legacy.html
+++ b/test/legacy.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>RUNNING</title>
+<script type="module">
+// Legacy-browser (Firefox 60 era) smoke test: no top-level await, no optional
+// chaining. The full wasm build requires SIMD and is deliberately absent.
+import { parse as parseMinAsm } from '../dist/lexer.minimal.asm.js';
+import { parse as parseFullAsm } from '../dist/lexer.asm.js';
+import { init, parse as parseMinWasm } from '../dist/lexer.minimal.js';
+
+var SOURCE = "import a from './b.js'; export const c = 1;";
+
+function check (parse, label) {
+  var result = parse(SOURCE);
+  if (result[0].length !== 1 || result[0][0].n !== './b.js')
+    throw new Error(label + ' imports');
+  if (result[1].length !== 1 || result[1][0].n !== 'c')
+    throw new Error(label + ' exports');
+}
+
+Promise.resolve()
+  .then(function () { check(parseMinAsm, 'minimal asm.js'); })
+  .then(function () { check(parseFullAsm, 'full asm.js'); })
+  .then(function () { return init; })
+  .then(function () { check(parseMinWasm, 'minimal wasm'); })
+  .then(function () { document.title = 'PASS'; })
+  .catch(function (err) { document.title = 'FAIL: ' + err.message; });
+</script>


### PR DESCRIPTION
Per #218: v3 support floor is Node.js 18+. The CI job now runs as a matrix over Node 18 and latest, and the README environment support section is branched by build: the full build requires Node.js 18+ / Wasm SIMD engines (Chrome 91+, Firefox 89+, Safari 16.4+), while the minimal build carries no SIMD requirement and the asm.js builds keep legacy browsers supported for es-module-shims. No `engines` field.