### PR TITLE
perf: localize SIMD to profitable scan paths

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -135,7 +135,7 @@ run = """
 	${{ EMSDK_PATH }}/emsdk install 6.0.0
 	${{ EMSDK_PATH }}/emsdk activate 6.0.0
 
-	${{ EMSDK_PATH }}/upstream/emscripten/emcc src/lexer.c -o lib/lexer.wasm -Oz -flto -msimd128 --no-entry -s STANDALONE_WASM=1 \
+	${{ EMSDK_PATH }}/upstream/emscripten/emcc src/lexer.c -o lib/lexer.wasm -Oz -flto -DLEXER_SIMD --no-entry -s STANDALONE_WASM=1 \
 	-s EXPORTED_FUNCTIONS="['_parse','_sa','_e','_ri','_re','_it','_is','_ie','_ss','_ip','_se','_ai','_id','_f','_ms','_ra','_rsa','_aks','_ake','_avs','_ave','_rt','_te','_rts','___heap_base']" \
 	-s SUPPORT_LONGJMP=0 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -Wno-logical-op-parentheses -Wno-parentheses
 """

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -9,9 +9,22 @@
 #include <stdio.h>
 #include <string.h>
 // SIMD scanning is full-build only: the minimal build favors footprint
-#if defined(__wasm_simd128__) && !defined(LEXER_MIN)
-#define LEXER_SIMD
+#if defined(LEXER_MIN)
+#undef LEXER_SIMD
+#elif defined(LEXER_SIMD)
+#define LEXER_SIMD_TARGET __attribute__((target("simd128")))
 #include <wasm_simd128.h>
+#elif defined(__wasm_simd128__)
+#define LEXER_SIMD
+#define LEXER_SIMD_TARGET
+#include <wasm_simd128.h>
+#endif
+
+#ifdef LEXER_SIMD
+// Sparse template files do not amortize vector setup; dense files do after a
+// short scalar warmup.
+#define TEMPLATE_SIMD_THRESHOLD 16
+static uint32_t template_scan_count;
 #endif
 
 static const char16_t XPORT[] = { 'x', 'p', 'o', 'r', 't' };
@@ -296,21 +309,6 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
   return true;
 }
 
-#ifdef LEXER_SIMD
-// first char at or after p not in {\t..\r, space}; the null sentinel stops the scan
-static inline char16_t* simdWsSkip (char16_t* p) {
-  for (;;) {
-    v128_t chunk = wasm_v128_load(p);
-    uint32_t bits = wasm_i16x8_bitmask(wasm_v128_or(
-        wasm_i16x8_eq(chunk, wasm_i16x8_splat(32)),
-        wasm_u16x8_lt(wasm_i16x8_sub(chunk, wasm_i16x8_splat(9)), wasm_i16x8_splat(5)))) ^ 0xFF;
-    if (bits)
-      return p + __builtin_ctz(bits);
-    p += 8;
-  }
-}
-#endif
-
 // Note: parsing is based on the _assumption_ that the source is already valid
 bool parse () {
   // stack allocations
@@ -332,6 +330,9 @@ bool parse () {
   openTokenStack = &openTokenStack_[0];
   dynamicImportStack = &dynamicImportStack_[0];
   nextBraceIsClass = false;
+#ifdef LEXER_SIMD
+  template_scan_count = 0;
+#endif
 
   pos = (char16_t*)(source - 1);
   char16_t ch = '\0';
@@ -343,11 +344,6 @@ bool parse () {
     ch = *pos;
 
     if (ch == 32 || ch < 14 && ch > 8) {
-#ifdef LEXER_SIMD
-      ch = *(pos + 1);
-      if (ch == 32 || ch < 14 && ch > 8)
-        pos = simdWsSkip(pos + 2) - 1;
-#endif
       continue;
     }
 
@@ -401,11 +397,6 @@ bool parse () {
     ch = *pos;
 
     if (ch == 32 || ch < 14 && ch > 8) {
-#ifdef LEXER_SIMD
-      ch = *(pos + 1);
-      if (ch == 32 || ch < 14 && ch > 8)
-        pos = simdWsSkip(pos + 2) - 1;
-#endif
       continue;
     }
 
@@ -1579,33 +1570,75 @@ char16_t commentWhitespace (bool br) {
 }
 
 #ifdef LEXER_SIMD
-// Returns the next position at or after p holding one of {a, b, c, d, e, 0}.
-// Relies on the source null sentinel to terminate; may overread one vector
-// past it. Padded duplicate chars at call sites are CSE'd away when inlined.
-__attribute__((always_inline))
-static inline char16_t* simdScan (char16_t* p, char16_t a, char16_t b, char16_t c, char16_t d, char16_t e) {
-  const v128_t va = wasm_i16x8_splat(a);
-  const v128_t vb = wasm_i16x8_splat(b);
-  const v128_t vc = wasm_i16x8_splat(c);
-  const v128_t vd = wasm_i16x8_splat(d);
-  const v128_t ve = wasm_i16x8_splat(e);
+// Returns the next template stop character at or after p. Relies on the source
+// null sentinel to terminate and may overread one vector past it.
+LEXER_SIMD_TARGET __attribute__((noinline))
+static char16_t* simdTemplateScan (char16_t* p) {
+  const v128_t dollar = wasm_i16x8_splat('$');
+  const v128_t backtick = wasm_i16x8_splat('`');
+  const v128_t slash = wasm_i16x8_splat('\\');
   const v128_t zero = wasm_i16x8_splat(0);
   for (;;) {
     v128_t chunk = wasm_v128_load(p);
-    uint32_t mask = wasm_i8x16_bitmask(wasm_v128_or(wasm_v128_or(
-        wasm_v128_or(wasm_i16x8_eq(chunk, va), wasm_i16x8_eq(chunk, vb)),
-        wasm_v128_or(wasm_i16x8_eq(chunk, vc), wasm_i16x8_eq(chunk, vd))),
-        wasm_v128_or(wasm_i16x8_eq(chunk, ve), wasm_i16x8_eq(chunk, zero))));
+    uint32_t mask = wasm_i8x16_bitmask(wasm_v128_or(
+        wasm_v128_or(wasm_i16x8_eq(chunk, dollar), wasm_i16x8_eq(chunk, backtick)),
+        wasm_v128_or(wasm_i16x8_eq(chunk, slash), wasm_i16x8_eq(chunk, zero))));
     if (mask)
       return p + __builtin_ctz(mask) / 2;
     p += 8;
   }
 }
 
+#endif
+
+static inline __attribute__((always_inline)) void templateStringScalar () {
+  while (pos++ < end) {
+    char16_t ch = *pos;
+    if (ch == '$' && *(pos + 1) == '{') {
+      pos++;
+      openTokenStack[openTokenDepth].token = TemplateBrace;
+      openTokenStack[openTokenDepth++].pos = pos;
+      return;
+    }
+    if (ch == '`') {
+      if (openTokenStack[--openTokenDepth].token != Template)
+        syntaxError();
+#ifndef LEXER_MIN
+      // The specifier template just closed. Note its closing backtick and stop
+      // recording (depth back to 0); finalization keeps the spans only if this
+      // backtick is the last token of the argument.
+      if (dynamicImportStackDepth > 0) {
+        Import* cur_dynamic_import = dynamicImportStack[dynamicImportStackDepth - 1];
+        if (cur_dynamic_import->specifier_template_depth == openTokenDepth + 1) {
+          cur_dynamic_import->template_close = pos;
+          cur_dynamic_import->specifier_template_depth = 0;
+        }
+      }
+#endif
+      return;
+    }
+    if (ch == '\\')
+      pos++;
+  }
+  syntaxError();
+}
+
+#ifdef LEXER_SIMD
 void templateString () {
+  if (template_scan_count < TEMPLATE_SIMD_THRESHOLD) {
+    template_scan_count++;
+    templateStringScalar();
+    return;
+  }
   char16_t* p = pos;
   for (;;) {
-    p = simdScan(p + 1, '$', '`', '\\', '$', '$');
+    char16_t next_ch = *(p + 1);
+    if (next_ch == '`')
+      p++;
+    else if (next_ch != '\\' && *(p + 2) == '`')
+      p += 2;
+    else
+      p = simdTemplateScan(p + 1);
     char16_t ch = *p;
     if (ch == '$') {
       if (*(p + 1) != '{')
@@ -1649,35 +1682,7 @@ void templateString () {
 }
 #else
 void templateString () {
-  while (pos++ < end) {
-    char16_t ch = *pos;
-    if (ch == '$' && *(pos + 1) == '{') {
-      pos++;
-      openTokenStack[openTokenDepth].token = TemplateBrace;
-      openTokenStack[openTokenDepth++].pos = pos;
-      return;
-    }
-    if (ch == '`') {
-      if (openTokenStack[--openTokenDepth].token != Template)
-        syntaxError();
-#ifndef LEXER_MIN
-      // The specifier template just closed. Note its closing backtick and stop
-      // recording (depth back to 0); finalization keeps the spans only if this
-      // backtick is the last token of the argument.
-      if (dynamicImportStackDepth > 0) {
-        Import* cur_dynamic_import = dynamicImportStack[dynamicImportStackDepth - 1];
-        if (cur_dynamic_import->specifier_template_depth == openTokenDepth + 1) {
-          cur_dynamic_import->template_close = pos;
-          cur_dynamic_import->specifier_template_depth = 0;
-        }
-      }
-#endif
-      return;
-    }
-    if (ch == '\\')
-      pos++;
-  }
-  syntaxError();
+  templateStringScalar();
 }
 #endif
 
@@ -1686,11 +1691,38 @@ void templateString () {
 // On success consumes it, leaves pos AT the closing backtick and returns true.
 // On a substitution or EOF restores pos and returns false, leaving the literal
 // to the main loop's template handling.
+static inline __attribute__((always_inline)) bool noSubstitutionTemplateScalar () {
+  char16_t* startPos = pos;
+  while (pos++ < end) {
+    char16_t ch = *pos;
+    if (ch == '`')
+      return true;
+    if (ch == '\\') {
+      pos++;
+      continue;
+    }
+    if (ch == '$' && *(pos + 1) == '{')
+      break;
+  }
+  pos = startPos;
+  return false;
+}
+
 #ifdef LEXER_SIMD
 bool noSubstitutionTemplate () {
+  if (template_scan_count < TEMPLATE_SIMD_THRESHOLD) {
+    template_scan_count++;
+    return noSubstitutionTemplateScalar();
+  }
   char16_t* p = pos;
   for (;;) {
-    p = simdScan(p + 1, '`', '\\', '$', '`', '`');
+    char16_t next_ch = *(p + 1);
+    if (next_ch == '`')
+      p++;
+    else if (next_ch != '\\' && *(p + 2) == '`')
+      p += 2;
+    else
+      p = simdTemplateScan(p + 1);
     char16_t ch = *p;
     if (ch == '`') {
       pos = p;
@@ -1714,42 +1746,10 @@ bool noSubstitutionTemplate () {
 }
 #else
 bool noSubstitutionTemplate () {
-  char16_t* startPos = pos;
-  while (pos++ < end) {
-    char16_t ch = *pos;
-    if (ch == '`')
-      return true;
-    if (ch == '\\') {
-      pos++;
-      continue;
-    }
-    if (ch == '$' && *(pos + 1) == '{')
-      break;
-  }
-  pos = startPos;
-  return false;
+  return noSubstitutionTemplateScalar();
 }
 #endif
 
-#ifdef LEXER_SIMD
-void blockComment (bool br) {
-  char16_t* p = pos + 1;
-  for (;;) {
-    p = simdScan(p + 1, '*', br ? '*' : '\n', br ? '*' : '\r', '*', '*');
-    char16_t ch = *p;
-    if (ch == '*') {
-      if (*(p + 1) != '/')
-        continue;
-      pos = p + 1;
-      return;
-    }
-    if (ch == 0 && p <= end)   // embedded null: keep looking
-      continue;
-    pos = p;                   // br char, or the sentinel at end + 1
-    return;
-  }
-}
-#else
 void blockComment (bool br) {
   pos++;
   // br is loop invariant and a comment body is scanned one character at a time,
@@ -1773,59 +1773,65 @@ void blockComment (bool br) {
     }
   }
 }
-#endif
 
 #ifdef LEXER_SIMD
+LEXER_SIMD_TARGET __attribute__((noinline))
+#endif
 void lineComment () {
-  char16_t* p = pos;
+#ifdef LEXER_SIMD
+  pos++;
+  // The unrolled prefix is faster than entering the vector loop for short comments.
+  char16_t* p = pos + 1;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  if (p > end || isBr(*p)) goto lineCommentEnd;
+  p++;
+  const v128_t newline = wasm_i16x8_splat('\n');
+  const v128_t carriage_return = wasm_i16x8_splat('\r');
+  const v128_t zero = wasm_i16x8_splat(0);
   for (;;) {
-    p = simdScan(p + 1, '\n', '\r', '\n', '\n', '\n');
-    if (*p != 0 || p > end) {   // newline, or the terminating sentinel
-      pos = p;
-      return;
+    v128_t chunk = wasm_v128_load(p);
+    uint32_t mask = wasm_i16x8_bitmask(wasm_v128_or(
+        wasm_i16x8_eq(chunk, zero),
+        wasm_v128_or(wasm_i16x8_eq(chunk, newline), wasm_i16x8_eq(chunk, carriage_return))));
+    if (mask) {
+      p += __builtin_ctz(mask);
+      if (*p != 0 || p > end) {
+        pos = p;
+        return;
+      }
+      p++;
     }
-    // embedded null: keep looking
+    else {
+      p += 8;
+    }
   }
-}
+
+lineCommentEnd:
+  pos = p;
 #else
-void lineComment () {
   while (pos++ < end) {
     char16_t ch = *pos;
     if (ch == '\n' || ch == '\r')
       return;
   }
-}
 #endif
-
-#ifdef LEXER_SIMD
-void stringLiteral (char16_t quote) {
-  char16_t* p = pos;
-  for (;;) {
-    p = simdScan(p + 1, quote, '\\', '\n', '\r', quote);
-    char16_t ch = *p;
-    if (ch == quote) {
-      pos = p;
-      return;
-    }
-    if (ch == '\\') {
-      p++;
-      if (*p == '\r' && *(p + 1) == '\n')
-        p++;
-      if (p > end) {
-        pos = p + 1;
-        syntaxError();
-        return;
-      }
-      continue;
-    }
-    if (ch == 0 && p <= end)   // embedded null: keep looking
-      continue;
-    pos = p;   // unescaped newline, or the terminating sentinel at end + 1
-    syntaxError();
-    return;
-  }
 }
-#else
+
 void stringLiteral (char16_t quote) {
   while (pos++ < end) {
     char16_t ch = *pos;
@@ -1841,67 +1847,7 @@ void stringLiteral (char16_t quote) {
   }
   syntaxError();
 }
-#endif
 
-#ifdef LEXER_SIMD
-char16_t regexCharacterClass () {
-  char16_t* p = pos;
-  for (;;) {
-    p = simdScan(p + 1, ']', '\\', '\n', '\r', ']');
-    char16_t ch = *p;
-    if (ch == ']') {
-      pos = p;
-      return ch;
-    }
-    if (ch == '\\') {
-      p++;
-      if (p > end) {
-        pos = p + 1;
-        break;
-      }
-      continue;
-    }
-    if (ch == 0 && p <= end)   // embedded null: keep looking
-      continue;
-    pos = p;   // unescaped newline, or the terminating sentinel at end + 1
-    break;
-  }
-  syntaxError();
-  return '\0';
-}
-
-void regularExpression () {
-  char16_t* p = pos;
-  for (;;) {
-    p = simdScan(p + 1, '/', '[', '\\', '\n', '\r');
-    char16_t ch = *p;
-    if (ch == '/') {
-      pos = p;
-      return;
-    }
-    if (ch == '[') {
-      pos = p;
-      if (regexCharacterClass() == '\0')
-        return;
-      p = pos;
-      continue;
-    }
-    if (ch == '\\') {
-      p++;
-      if (p > end) {
-        pos = p + 1;
-        break;
-      }
-      continue;
-    }
-    if (ch == 0 && p <= end)   // embedded null: keep looking
-      continue;
-    pos = p;   // unescaped newline, or the terminating sentinel at end + 1
-    break;
-  }
-  syntaxError();
-}
-#else
 char16_t regexCharacterClass () {
   while (pos++ < end) {
     char16_t ch = *pos;
@@ -1930,54 +1876,7 @@ void regularExpression () {
   }
   syntaxError();
 }
-#endif
 
-#ifdef LEXER_SIMD
-// vector isBrOrWs(c) || isPunctuator(c) || c == 0
-static inline v128_t stopMask (v128_t c) {
-  #define EQ(n)      wasm_i16x8_eq(c, wasm_i16x8_splat(n))
-  #define RANGE(a,n) wasm_u16x8_lt(wasm_i16x8_sub(c, wasm_i16x8_splat(a)), wasm_i16x8_splat(n))
-  v128_t m =            RANGE(9, 5);      // \t \n \v \f \r
-  m = wasm_v128_or(m, EQ(32));            // space
-  m = wasm_v128_or(m, EQ(160));           // nbsp
-  m = wasm_v128_or(m, EQ('!'));
-  m = wasm_v128_or(m, EQ('%'));
-  m = wasm_v128_or(m, EQ('&'));
-  m = wasm_v128_or(m, RANGE(40, 8));      // ( ) * + , - . /
-  m = wasm_v128_or(m, RANGE(58, 6));      // : ; < = > ?
-  m = wasm_v128_or(m, EQ('['));
-  m = wasm_v128_or(m, EQ(']'));
-  m = wasm_v128_or(m, EQ('^'));
-  m = wasm_v128_or(m, RANGE(123, 4));     // { | } ~
-  m = wasm_v128_or(m, EQ(0));             // sentinel / any null (matches scalar)
-  return m;
-  #undef EQ
-  #undef RANGE
-}
-
-char16_t readToWsOrPunctuator (char16_t ch) {
-  for (;;) {
-    v128_t chunk = wasm_v128_load(pos);
-    uint32_t bits = wasm_i16x8_bitmask(stopMask(chunk));
-    if (!bits) {
-      pos += 8;
-      continue;
-    }
-    pos += __builtin_ctz(bits);
-    ch = *pos;
-    // The '{' of a \u{...} identifier escape is part of the run, not a
-    // punctuator: step over the whole escape and keep scanning.
-    if (ch == '{' && pos - source >= 2 && *(pos - 1) == 'u' && *(pos - 2) == '\\') {
-      pos -= 2;
-      if (skipBracedEscape() < 0)
-        return '\0';
-      pos++;
-      continue;
-    }
-    return ch;
-  }
-}
-#else
 char16_t readToWsOrPunctuator (char16_t ch) {
   do {
 #ifndef LEXER_MIN
@@ -1995,7 +1894,6 @@ char16_t readToWsOrPunctuator (char16_t ch) {
   } while (ch = *(++pos));
   return ch;
 }
-#endif
 
 // Note: non-asii BR and whitespace checks omitted for perf / footprint
 // if there is a significant user need this can be reconsidered

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -506,6 +506,10 @@ suite('Lexer', () => {
     // same as for the quoted forms.
     assert.strictEqual(parse('import("./x.js")')[0][0].n, './x.js');
     assert.strictEqual(parse("import('./x.js')")[0][0].n, './x.js');
+    const scalarTemplateWarmup = '``;'.repeat(16);
+    assert.strictEqual(parse(scalarTemplateWarmup + 'import(``)')[0][0].n, '');
+    assert.strictEqual(parse(scalarTemplateWarmup + 'import(`a`)')[0][0].n, 'a');
+    assert.strictEqual(parse(scalarTemplateWarmup + 'import(`$`)')[0][0].n, '$');
     assert.strictEqual(parse('import(`./x.js`)')[0][0].n, './x.js');
   });
 
@@ -1328,6 +1332,19 @@ function x() {
     assert.strictEqual(source.slice(imports[0].ss, imports[0].se), `import util from 'util'`);
     assert.strictEqual(exports.length, 1);
     assertExportIs(source, exports[0], { n: 'a', ln: 'a' });
+  });
+
+  test('Line comments preserve scalar and SIMD scan boundaries', () => {
+    for (const [length, terminator] of [[8, '\n'], [9, '\n'], [9, '\r']]) {
+      const [imports] = parse(`//${'x'.repeat(length)}${terminator}import 'boundary';`);
+      assert.strictEqual(imports.length, 1);
+      assert.strictEqual(imports[0].n, 'boundary');
+    }
+
+    const [imports] = parse(`//${'x'.repeat(9)}\0tail\nimport 'embedded-null';`);
+    assert.strictEqual(imports.length, 1);
+    assert.strictEqual(imports[0].n, 'embedded-null');
+    assert.deepStrictEqual(parse(`//${'x'.repeat(9)}`)[0], []);
   });
 
   test('Strings', () => {


### PR DESCRIPTION
SIMD setup dominates short scans, and whole-module `-msimd128` also changes scalar hot paths. This keeps short and unrelated scans scalar, then uses SIMD for long line comments and templates. Non-SIMD builds remain byte-identical to v3.

Long line-comment scans improve 9-65%, and long templates improve 66.8% against the SHA-identical scalar control on Node 18 arm64. The complete 3.06 MB sample corpus shows no aggregate regression across Node 18-26. Two isolated-process runs each produced a 0.94% equal-version geomean improvement. The SIMD build is 563 bytes smaller than #231.