### PR TITLE
fix: forward the sourcename through the pre-init parse path

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -242,7 +242,7 @@ export function parse (source: string, name = '@'): readonly [
   if (!wasm)
     // actually returns a promise if init hasn't resolved (not type safe).
     // casting to avoid a breaking type change.
-    return init.then(() => parse(source)) as unknown as ReturnType<typeof parse>;
+    return init.then(() => parse(source, name)) as unknown as ReturnType<typeof parse>;
 
   const len = source.length + 1;
 

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -2091,6 +2091,19 @@ export { d as a, p as b, z as c, r as d, q }`;
     }
   });
 
+  // Only the wasm builds have a pre-init branch, reached by the documented
+  // "either await init, or call parse asynchronously" path.
+  if (process.env.WASM) {
+    test('Sourcename on the pre-init async path', async () => {
+      // The query string yields a second, uninitialized instance; the one this
+      // file imported has already awaited init.
+      const { parse } = await import(min ? '../dist/lexer.minimal.js?preinit' : '../dist/lexer.js?preinit');
+      const pending = parse('import{', 'my-file.js');
+      assert(pending instanceof Promise, 'init resolved first, so the pre-init path was not exercised');
+      await assert.rejects(pending, /^Error: Parse error my-file\.js:\d+:\d+$/);
+    });
+  }
+
   test('Large source', () => {
     const source = `import 'a';\nconst x = "${'a'.repeat(5 * 1024 * 1024)}";\nexport { x }`;
     const [imports, exports] = parse(source);


### PR DESCRIPTION
When `parse()` is called before `init` resolves, it recurses as `parse(source)` and drops `name`, which then falls back to its `'@'` default. The README documents the second argument (`parse(source, 'optional-sourcename')`) and it documents calling parse before init ("either await init, or call parse asynchronously"), but the two don't compose:

```js
parse('import{', 'my-file.js')
// after awaiting init:  Parse error my-file.js:1:11
// before awaiting init: Parse error @:1:11
```

So anyone lexing a batch of files on the async path gets every error labelled `@`.

The fix is to pass `name` through the recursion. Only the wasm builds have this branch — `src/lexer.asm.js` and the plain JS build parse synchronously from the first call.

The test goes in the `Invalid syntax` suite behind the `WASM` gate. It imports a second module instance via a query string, since the suite's own instance has already awaited `init` and can't reach the branch. Verified it fails with `Parse error @:1:11` without the fix. `test:wasm` and `test:minimal:wasm` pass (150 each).

I left the `as unknown as` cast on that line alone deliberately — that's #155 and it needs a breaking type change, which didn't belong in the same diff.

Disclosure: I used an AI assistant while working on this. I reproduced the bug, reviewed the change, and ran the test suite myself.