### PR TITLE
fix: make parse type-safe via automatic synchronous initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,25 @@ See [src/lexer.ts](src/lexer.ts) for the type definitions.
 For use in CommonJS:
 
 ```js
-const { init, parse } = require('es-module-lexer');
+const { parse } = require('es-module-lexer');
 
-(async () => {
-  // either await init, or call parse asynchronously
-  // this is necessary for the Web Assembly boot
-  await init;
+const source = 'export var p = 5';
+const [imports, exports] = parse(source);
 
-  const source = 'export var p = 5';
-  const [imports, exports] = parse(source);
+// Returns "p"
+source.slice(exports[0].start, exports[0].end);
+```
 
-  // Returns "p"
-  source.slice(exports[0].start, exports[0].end);
-})();
+`parse` initializes the WebAssembly automatically on first use, compiling it
+synchronously if the `init` promise has not been awaited. Browser main threads
+restrict synchronous WebAssembly compilation, so `init` must be awaited
+there first:
+
+```js
+import { init, parse } from 'es-module-lexer';
+
+await init;
+parse(source);
 ```
 
 An ES module version is also available:

--- a/README.md
+++ b/README.md
@@ -40,26 +40,24 @@ See [src/lexer.ts](src/lexer.ts) for the type definitions.
 For use in CommonJS:
 
 ```js
-const { parse } = require('es-module-lexer');
+const { init, parse } = require('es-module-lexer');
 
-const source = 'export var p = 5';
-const [imports, exports] = parse(source);
+(async () => {
+  // in browsers, await init first for the WebAssembly boot
+  await init;
 
-// Returns "p"
-source.slice(exports[0].start, exports[0].end);
+  const source = 'export var p = 5';
+  const [imports, exports] = parse(source);
+
+  // Returns "p"
+  source.slice(exports[0].start, exports[0].end);
+})();
 ```
 
 `parse` initializes the WebAssembly automatically on first use, compiling it
 synchronously if the `init` promise has not been awaited. Browser main threads
-restrict synchronous WebAssembly compilation, so `init` must be awaited
-there first:
-
-```js
-import { init, parse } from 'es-module-lexer';
-
-await init;
-parse(source);
-```
+restrict synchronous WebAssembly compilation, so awaiting `init` remains
+required there, while in Node.js and other environments it is optional.
 
 An ES module version is also available:
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -313,9 +313,9 @@ export function parse (source: string, name = '@'): readonly [
   hasModuleSyntax: boolean
 ] {
   if (!wasm)
-    // actually returns a promise if init hasn't resolved (not type safe).
-    // casting to avoid a breaking type change.
-    return init.then(() => parse(source, name)) as unknown as ReturnType<typeof parse>;
+    // synchronous compile is restricted on browser main threads — await init
+    // there before calling parse
+    initSync();
 
   const len = source.length + 1;
 

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -2901,16 +2901,21 @@ export { d as a, p as b, z as c, r as d, q }`;
     }
   });
 
-  // Only the wasm builds have a pre-init branch, reached by the documented
-  // "either await init, or call parse asynchronously" path.
+  // Only the wasm builds require initialization; the asm.js builds are always
+  // synchronous.
   if (process.env.WASM) {
-    test('Sourcename on the pre-init async path', async () => {
+    test('parse initializes synchronously when init is not awaited', async () => {
       // The query string yields a second, uninitialized instance; the one this
       // file imported has already awaited init.
       const { parse } = await import(min ? '../dist/lexer.minimal.js?preinit' : '../dist/lexer.js?preinit');
-      const pending = parse('import{', 'my-file.js');
-      assert(pending instanceof Promise, 'init resolved first, so the pre-init path was not exercised');
-      await assert.rejects(pending, /^Error: Parse error my-file\.js:\d+:\d+$/);
+      const [imports, exports] = parse(`import 'a'; export var p = 5`);
+      assert.strictEqual(imports.length, 1);
+      assert.strictEqual(exports.length, 1);
+    });
+
+    test('Sourcename on the pre-init path', async () => {
+      const { parse } = await import(min ? '../dist/lexer.minimal.js?preinit-err' : '../dist/lexer.js?preinit-err');
+      assert.throws(() => parse('import{', 'my-file.js'), /^Error: Parse error my-file\.js:\d+:\d+$/);
     });
   }
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -2,6 +2,8 @@ import type {
   Import,
   Export,
 } from '../types/lexer.js';
+import { parse } from '../types/lexer.js';
+import { parse as minimalParse } from '../types/lexer.minimal.js';
 import type {
   ImportSpecifier as MinimalImportSpecifier,
   ExportSpecifier as MinimalExportSpecifier,
@@ -66,3 +68,12 @@ declare const minimalExportSpecifier: MinimalExportSpecifier;
 minimalExportSpecifier.ln;
 // @ts-expect-error Minimal export records keep the v2 shape.
 minimalExportSpecifier.t;
+
+// parse is synchronous — no promise in its return type.
+const syncImports: ReadonlyArray<Import> = parse('')[0];
+syncImports;
+// @ts-expect-error parse does not return a promise.
+parse('').then;
+
+const minimalSyncImports: ReadonlyArray<MinimalImportSpecifier> = minimalParse('')[0];
+minimalSyncImports;


### PR DESCRIPTION
This makes `parse` fully synchronous, resolving #155 as a v3 breaking change.

Previously `parse` returned a promise on the pre-init path, hidden from the type system by a cast, so un-awaited calls type-checked but returned a promise at runtime. Instead of widening the types, the runtime now matches the synchronous signature:

* `parse` calls `initSync()` internally when the wasm is not yet instantiated, so Node callers no longer need to await `init` at all
* browser main threads restrict synchronous WebAssembly compilation, so `await init` remains required there, now documented in the README
* the implicit pre-init promise-returning behavior is removed

Test coverage: the pre-init unit tests now assert synchronous auto-initialization and sourcename forwarding on a fresh uninitialized instance, and test/types.ts asserts `parse` has no promise in its return type.