### PR TITLE
feat: always validate static specifier unicode in full build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Build Status][actions-image]][actions-url]
 
-A JS module syntax lexer used in [es-module-shims](https://github.com/guybedford/es-module-shims).
+A JS/TS module syntax lexer used in [es-module-shims](https://github.com/guybedford/es-module-shims).
 
-Outputs the list of exports and locations of import specifiers, including dynamic import and import meta handling.
+Outputs the list and locations of exports and import specifiers, including dynamic import and import meta expressions.
 
-Supports new syntax features including import attributes and source phase imports.
+Supports new syntax features including import attributes, deferred evaluation, and source phase imports.
 
-A very small single JS file (~7KiB gzipped for the [minimal build](#minimal-build)) that includes inlined Web Assembly for very fast source analysis of ECMAScript module syntax only.
+A very small single JS file (~7KiB gzipped for the [minimal build](#minimal-build)) that includes inlined WebAssembly for very fast source analysis of ECMAScript module syntax only.
 
 For an example of the performance, Angular 1 (720KiB) is fully parsed in 1ms, in comparison to the fastest JS parser, Acorn which takes over 100ms.
 
@@ -75,8 +75,9 @@ type Import = StaticImport | DynamicImport | ImportMetaRef;
 interface StaticImport {
   // 'reexport-star' is the module request of `export * from 'mod'`
   type: 'static' | 'reexport-star';
-  // decoded specifier, undefined when it does not decode as a JS string
-  specifier: string | undefined;
+  // decoded specifier with escape sequences processed (invalid escape
+  // sequences are a parse error)
+  specifier: string;
   phase: 'source' | 'defer' | null;
   // module specifier range
   start: number;
@@ -273,9 +274,9 @@ imports[0].attributes;
 
 ### Escape Sequences
 
-To handle escape sequences in specifier strings, the `specifier` field of
-imports is decoded where possible, and is `undefined` when the specifier does
-not decode as a JS string.
+Escape sequences in specifier strings are decoded into the `specifier` field.
+A specifier that does not decode as a JS string (an invalid escape sequence)
+throws a parse error, just like the source would in a JS engine.
 
 When the entire dynamic import argument is a single template literal,
 `specifier` is reported as a glob: each `${...}` substitution is collapsed to
@@ -422,7 +423,8 @@ source.slice(exports[0].ls, exports[0].le);
 
 Interpolated template specifiers are not globbed in the minimal build (`n` is
 `undefined` for them), and escape sequences in specifiers are decoded into
-`n` where possible just as in the full build.
+`n` just as in the full build, including the parse error on invalid escape
+sequences.
 
 ## CSP asm.js Build
 
@@ -436,7 +438,7 @@ For versions that work with CSP eval disabled, use the `es-module-lexer/js` and 
 import { parse } from 'es-module-lexer/js';
 ```
 
-Instead of Web Assembly, these use an asm.js build which is almost as fast as the Wasm version ([see benchmarks below](#benchmarks)).
+Instead of WebAssembly, these use an asm.js build which is almost as fast as the Wasm version ([see benchmarks below](#benchmarks)).
 
 ### Environment Support
 

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -284,27 +284,18 @@ function readEscapedChar () {
 
 function readHexChar (len) {
   const start = acornPos;
-  let total = 0, lastCode = 0;
+  let total = 0;
   for (let i = 0; i < len; ++i, ++acornPos) {
     let code = source.charCodeAt(acornPos), val;
-
-    if (code === 95) {
-      if (lastCode === 95 || i === 0) syntaxError();
-      lastCode = code;
-      continue;
-    }
-
     if (code >= 97) val = code - 97 + 10; // a
     else if (code >= 65) val = code - 65 + 10; // A
     else if (code >= 48 && code <= 57) val = code - 48; // 0-9
     else break;
     if (val >= 16) break;
-    lastCode = code;
     total = total * 16 + val;
   }
-
-  if (lastCode === 95 || acornPos - start !== len) syntaxError();
-
+  // len < 1 covers empty and unterminated \u{} escapes
+  if (len < 1 || acornPos - start !== len) syntaxError();
   return total;
 }
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -97,10 +97,11 @@ export interface StaticImport extends ImportBase {
    */
   readonly type: 'static' | 'reexport-star';
   /**
-   * Decoded module specifier, handling escape sequences where possible;
-   * `undefined` when the specifier string does not decode as JS.
+   * Decoded module specifier with escape sequences processed. A specifier
+   * that does not decode as a JS string (invalid escape sequences) is a
+   * parse error.
    */
-  readonly specifier: string | undefined;
+  readonly specifier: string;
   readonly phase: ImportPhase;
   /**
    * Parsed import attributes as an array of [key, value] tuples.
@@ -341,7 +342,7 @@ export function parse (source: string, name = '@'): readonly [
     const s = wasm.is(), e = wasm.ie(), t = wasm.it(), a = wasm.ai(), d = wasm.id(), ss = wasm.ss(), se = wasm.se();
     let n;
     if (wasm.ip())
-      n = decode(source.slice(d === -1 ? s - 1 : s, d === -1 ? e + 1 : e));
+      n = decode(source.slice(d === -1 ? s - 1 : s, d === -1 ? e + 1 : e), s);
     else if (!MINIMAL && d !== -1 && source[s] === '`')
       n = decodeTemplate(s, e);
     let at: Array<[string, string]> | null = null;
@@ -352,7 +353,7 @@ export function parse (source: string, name = '@'): readonly [
       wasm.rsa();
       while (wasm.ra()) {
         const aks = wasm.aks(), ake = wasm.ake(), avs = wasm.avs(), ave = wasm.ave();
-        at.push([decodeIfQuoted(source.slice(aks, ake)), decodeIfQuoted(source.slice(avs, ave))]);
+        at.push([decodeIfQuoted(source.slice(aks, ake), aks), decodeIfQuoted(source.slice(avs, ave), avs)]);
       }
       if (at.length === 0) at = null;
     }
@@ -368,7 +369,7 @@ export function parse (source: string, name = '@'): readonly [
     }
     else {
       const phase: ImportPhase = t === ImportType.StaticSourcePhase ? 'source' : t === ImportType.StaticDeferPhase ? 'defer' : null;
-      imports.push({ type: t === ImportType.StaticReexportStar ? 'reexport-star' : 'static', specifier: n, phase, start: s, end: e, importStart: ss, importEnd: se, attributes: at, attributesStart: a });
+      imports.push({ type: t === ImportType.StaticReexportStar ? 'reexport-star' : 'static', specifier: n!, phase, start: s, end: e, importStart: ss, importEnd: se, attributes: at, attributesStart: a });
     }
   }
   let exportPtr = wasm.re();
@@ -376,8 +377,8 @@ export function parse (source: string, name = '@'): readonly [
   while (exportPtr !== 0) {
     if (MINIMAL) {
       const s = wasm.es(), e = wasm.ee(), ls = wasm.els(), le = wasm.ele();
-      const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le));
-      const n = decodeIfQuoted(source.slice(s, e));
+      const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le), ls);
+      const n = decodeIfQuoted(source.slice(s, e), s);
       exports.push({ s, e, ls, le, n, ln } as unknown as Export);
       exportPtr = wasm.re();
       continue;
@@ -394,18 +395,18 @@ export function parse (source: string, name = '@'): readonly [
     const fi = memoryView!.getUint32(exportPtr + 20, true);
     const t = memoryView!.getUint8(exportPtr + 24) as ExportType;
     if (t === ExportType.ReexportAll) {
-      exports.push({ type: 'reexport-all', from: (imports[fi] as StaticImport).specifier as string, importIndex: fi, start: s, end: e, exportStart: ss });
+      exports.push({ type: 'reexport-all', from: (imports[fi] as StaticImport).specifier, importIndex: fi, start: s, end: e, exportStart: ss });
     }
     else {
-      const n = decodeIfQuoted(source.slice(s, e));
+      const n = decodeIfQuoted(source.slice(s, e), s);
       if (t === ExportType.Direct) {
-        const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le));
+        const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le), ls);
         exports.push({ type: 'direct', name: n, localName: ln, start: s, end: e, localStart: ls, localEnd: le, exportStart: ss });
       }
       else {
         const importNameType = memoryView!.getUint8(exportPtr + 25);
         const im = importNameType === 0
-          ? decodeIfQuoted(source.slice(ls, le))
+          ? decodeIfQuoted(source.slice(ls, le), ls)
           : importNameType === 1 ? 'default' : null;
         exports.push({
           type: 'reexport',
@@ -413,7 +414,7 @@ export function parse (source: string, name = '@'): readonly [
           importName: im,
           importNameStart: importNameType === 0 ? ls : -1,
           importNameEnd: importNameType === 0 ? le : -1,
-          from: (imports[fi] as StaticImport).specifier as string,
+          from: (imports[fi] as StaticImport).specifier,
           importIndex: fi,
           start: s,
           end: e,
@@ -424,18 +425,21 @@ export function parse (source: string, name = '@'): readonly [
     exportPtr = wasm.re();
   }
 
-  function decode (str: string) {
+  // strict mode matches the asm build's eval-free decoder in rejecting
+  // legacy octal escapes
+  function decode (str: string, idx: number): string {
     try {
-      return (0, eval)(str)
+      return (0, eval)('"use strict";' + str)
     }
-    catch (e) {}
+    catch (e) {
+      throw Object.assign(new Error(`Parse error ${name}:${source.slice(0, idx).split('\n').length}:${idx - source.lastIndexOf('\n', idx - 1)}`), { idx });
+    }
   }
 
-  function decodeIfQuoted (str: string): string {
-    if (!str) return str;
+  function decodeIfQuoted (str: string, idx: number): string {
     const firstChar = str[0];
     if (firstChar === '"' || firstChar === "'")
-      return decode(str) || str;
+      return decode(str, idx);
     return str;
   }
 

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -953,6 +953,18 @@ suite('Lexer', () => {
     assert.strictEqual(imports[5].n, undefined);
   })
 
+  test('Invalid string escapes throw', () => {
+    // the asm decoder reports the exact bad char, eval decode the string start
+    assert.throws(() => parse(`import './\\uZZ.js'`, 'invalid.js'), /^Error: Parse error invalid\.js:1:\d+$/);
+    assert.throws(() => parse(`import('./\\u{FFFFFF}.js')`));
+    assert.throws(() => parse(`export { a as "\\uZZ" } from 'b'`));
+    // legacy octal escapes are invalid in module strict mode
+    assert.throws(() => parse(`import './\\01.js'`));
+    // the minimal build never decodes the attribute list
+    if (!min)
+      assert.throws(() => parse(`import 'a' with { type: "\\uZZ" }`));
+  })
+
   test('Regexp case', () => {
     parse(`
       class Number {

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -960,6 +960,9 @@ suite('Lexer', () => {
     assert.throws(() => parse(`export { a as "\\uZZ" } from 'b'`));
     // legacy octal escapes are invalid in module strict mode
     assert.throws(() => parse(`import './\\01.js'`));
+    // empty and separator-containing escapes are invalid
+    assert.throws(() => parse(`import './\\u{}.js'`));
+    assert.throws(() => parse(`import './\\u0_00.js'`));
     // the minimal build never decodes the attribute list
     if (!min)
       assert.throws(() => parse(`import 'a' with { type: "\\uZZ" }`));

--- a/test/types.ts
+++ b/test/types.ts
@@ -14,7 +14,7 @@ declare const imported: Import;
 switch (imported.type) {
   case 'static':
   case 'reexport-star':
-    imported.specifier;
+    imported.specifier satisfies string;
     imported.attributes;
     // @ts-expect-error Only dynamic imports have a dynamic argument start.
     imported.dynamicStart;


### PR DESCRIPTION
This updates `StaticImport.specifier` so that it is now always a string; invalid escapes throw a positioned Parse error instead. All suites pass (wasm, asm, minimal × both, types).

What surfaced along the way: the asm (CSP) builds were already strict — src/lexer.asm.js has an eval-free acorn-style decoder that validates escapes and throws — only the eval-based wasm wrapper was lenient. So this change actually unifies a pre-existing build divergence rather than just tightening types:

- decode in src/lexer.ts now evals with a "use strict" prologue (matching the asm decoder in also rejecting legacy octal escapes like '\01', which sloppy eval silently accepted as \x01) and throws Parse error <name>:<line>:<col> with idx on failure — same message shape as the asm build. Applies uniformly: specifiers, string export names, and attribute keys/values, in full and minimal builds alike.
- DynamicImport.specifier stays string | undefined — undefined now exclusively means "not statically analyzable" (non-literal argument, non-glob template).
- Dropped the two as string casts on from: that the old type forced.
- README + doc comments updated; new test covers \uZZ, out-of-range \u{FFFFFF}, string export names, octal, and attributes (attributes gated !min since minimal never decodes them).

One residual asymmetry, deliberate: the asm decoder reports the exact offending character's position, while the eval path can only report the string's start (eval doesn't say where it failed). The test asserts the message shape without pinning the column.