### PR TITLE
perf: decode module strings without eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,11 +480,11 @@ sequences.
 
 ## CSP asm.js Build
 
-The default versions of the library use Wasm and (safe) eval usage for performance and a minimal footprint.
+The default builds use Wasm without generating code from strings. They work when JavaScript eval is disabled,
+including Node.js with `--disallow-code-generation-from-strings`, if the environment permits WebAssembly compilation.
 
-Neither of these represent security escalation possibilities since there are no execution string injection vectors, but that can still violate existing CSP policies for applications.
-
-For versions that work with CSP eval disabled, use the `es-module-lexer/js` and `es-module-lexer/minimal/js` builds:
+For CSP policies that also disable WebAssembly compilation, use the `es-module-lexer/js` and
+`es-module-lexer/minimal/js` builds:
 
 ```js
 import { parse } from 'es-module-lexer/js';

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -262,7 +262,8 @@ name = 'test'
 deps = [
   'test:wasm', 'test:asm', 'test:minimal:wasm', 'test:minimal:asm',
   'test:types', 'test:ts:wasm', 'test:ts:asm',
-  'test:no-eval', 'test:no-eval:cjs', 'test:no-eval:minimal'
+  'test:no-eval', 'test:no-eval:cjs',
+  'test:no-eval:minimal', 'test:no-eval:minimal:cjs'
 ]
 
 [[task]]
@@ -306,6 +307,12 @@ run = 'node --disallow-code-generation-from-strings node_modules/mocha/bin/mocha
 name = 'test:no-eval:minimal'
 deps = ['dist/lexer.minimal.js']
 env = { MINIMAL = '1' }
+run = 'node --disallow-code-generation-from-strings node_modules/mocha/bin/mocha.js -b -u tdd test/no-eval/index.cjs'
+
+[[task]]
+name = 'test:no-eval:minimal:cjs'
+deps = ['dist/lexer.minimal.cjs']
+env = { CJS = '1', MINIMAL = '1' }
 run = 'node --disallow-code-generation-from-strings node_modules/mocha/bin/mocha.js -b -u tdd test/no-eval/index.cjs'
 
 [[task]]

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -259,7 +259,11 @@ run = 'node build/combine-asm.mjs'
 
 [[task]]
 name = 'test'
-deps = ['test:wasm', 'test:asm', 'test:minimal:wasm', 'test:minimal:asm', 'test:types', 'test:ts:wasm', 'test:ts:asm']
+deps = [
+  'test:wasm', 'test:asm', 'test:minimal:wasm', 'test:minimal:asm',
+  'test:types', 'test:ts:wasm', 'test:ts:asm',
+  'test:no-eval', 'test:no-eval:cjs', 'test:no-eval:minimal'
+]
 
 [[task]]
 # Differential fuzz against Node type stripping; random seed each run, printed
@@ -286,6 +290,23 @@ name = 'test:wasm'
 deps = ['dist/lexer.js']
 env = { WASM = '1' }
 run = 'mocha -b -u tdd test/*.cjs'
+
+[[task]]
+name = 'test:no-eval'
+deps = ['dist/lexer.js']
+run = 'node --disallow-code-generation-from-strings node_modules/mocha/bin/mocha.js -b -u tdd test/no-eval/index.cjs'
+
+[[task]]
+name = 'test:no-eval:cjs'
+deps = ['dist/lexer.cjs']
+env = { CJS = '1' }
+run = 'node --disallow-code-generation-from-strings node_modules/mocha/bin/mocha.js -b -u tdd test/no-eval/index.cjs'
+
+[[task]]
+name = 'test:no-eval:minimal'
+deps = ['dist/lexer.minimal.js']
+env = { MINIMAL = '1' }
+run = 'node --disallow-code-generation-from-strings node_modules/mocha/bin/mocha.js -b -u tdd test/no-eval/index.cjs'
 
 [[task]]
 name = 'test:minimal:asm'

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -68,7 +68,7 @@ export function parse (_source, _name = '@') {
     const a = asm.ai(), d = asm.id(), ss = asm.ss(), se = asm.se();
     let n;
     if (asm.ip())
-      n = readString(d === -1 ? s : s + 1, source.charCodeAt(d === -1 ? s - 1 : s));
+      n = readString(d === -1 ? s : s + 1, d === -1 ? e : e - 1);
     else if (!MINIMAL && d !== -1 && source.charCodeAt(s) === 96/*`*/)
       n = decodeTemplate(s, e);
     let at = null;
@@ -146,7 +146,7 @@ export function parse (_source, _name = '@') {
   function decodeIfQuoted (pos, end) {
     const ch = source.charCodeAt(pos);
     if (ch === 34 || ch === 39)
-      return readString(pos + 1, ch);
+      return readString(pos + 1, end - 1);
     return source.slice(pos, end);
   }
 }
@@ -177,28 +177,95 @@ export function parse (_source, _name = '@') {
  * THE SOFTWARE.
  */
 let acornPos;
-function readString (start, quote) {
-  acornPos = start;
-  let out = '', chunkStart = acornPos;
-  for (;;) {
-    if (acornPos >= source.length) syntaxError();
-    const ch = source.charCodeAt(acornPos);
-    if (ch === quote) break;
-    if (ch === 92) { // '\'
-      out += source.slice(chunkStart, acornPos);
-      out += readEscapedChar();
-      chunkStart = acornPos;
+/**
+ * @param {number} start Start of the string contents.
+ * @param {number} end End of the string contents.
+ * @returns {string}
+ */
+function readString (start, end) {
+  let escape = source.indexOf('\\', start);
+  if (escape === -1 || escape >= end)
+    return source.slice(start, end);
+
+  let decoded = source.slice(start, escape);
+  while (escape < end) {
+    let index = escape + 1;
+    if (index >= end) {
+      acornPos = index;
+      syntaxError();
     }
-    else if (ch === 0x2028 || ch === 0x2029) {
-      ++acornPos;
+
+    const char = source.charCodeAt(index++);
+    switch (char) {
+      case 13:
+        if (source.charCodeAt(index) === 10) index++;
+        break;
+      case 10:
+      case 0x2028:
+      case 0x2029:
+        break;
+      case 114: decoded += '\r'; break;
+      case 110: decoded += '\n'; break;
+      case 116: decoded += '\t'; break;
+      case 98: decoded += '\b'; break;
+      case 102: decoded += '\f'; break;
+      case 118: decoded += '\u000b'; break;
+      case 120:
+        decoded += String.fromCharCode(readHex(index, 2));
+        index += 2;
+        break;
+      case 117: {
+        let codePoint;
+        if (source.charCodeAt(index) === 123) {
+          const close = source.indexOf('}', ++index);
+          if (close === -1 || close >= end) {
+            acornPos = index;
+            syntaxError();
+          }
+          codePoint = readHex(index, close - index);
+          index = close + 1;
+        }
+        else {
+          codePoint = readHex(index, 4);
+          index += 4;
+        }
+        if (codePoint > 0x10ffff) {
+          acornPos = index;
+          syntaxError();
+        }
+        if (codePoint <= 0xffff) {
+          decoded += String.fromCharCode(codePoint);
+        }
+        else {
+          codePoint -= 0x10000;
+          decoded += String.fromCharCode((codePoint >> 10) + 0xd800, (codePoint & 1023) + 0xdc00);
+        }
+        break;
+      }
+      case 48: {
+        const next = source.charCodeAt(index);
+        if (next >= 48 && next <= 57) {
+          acornPos = index;
+          syntaxError();
+        }
+        decoded += '\0';
+        break;
+      }
+      default:
+        if (char >= 49 && char <= 57) {
+          acornPos = index - 1;
+          syntaxError();
+        }
+        decoded += String.fromCharCode(char);
     }
-    else {
-      if (isBr(ch) && quote !== 96/*`*/) syntaxError();
-      ++acornPos;
-    }
+
+    const nextEscape = source.indexOf('\\', index);
+    if (nextEscape === -1 || nextEscape >= end)
+      return decoded + source.slice(index, end);
+    decoded += source.slice(index, nextEscape);
+    escape = nextEscape;
   }
-  out += source.slice(chunkStart, acornPos++);
-  return out;
+  return decoded;
 }
 
 // Glob for a lone interpolated-template specifier starting at `s`. The parser
@@ -240,91 +307,32 @@ function decodeTemplate (s, e) {
   return out + source.slice(chunkStart, index);
 }
 
-// Used to read escaped characters
+/**
+ * @param {number} start Start of the hexadecimal digits.
+ * @param {number} length Number of hexadecimal digits.
+ * @returns {number}
+ */
+function readHex (start, length) {
+  if (length < 1 || start + length > source.length) {
+    acornPos = start;
+    syntaxError();
+  }
 
-function readEscapedChar () {
-  let ch = source.charCodeAt(++acornPos);
-  ++acornPos;
-  switch (ch) {
-    case 110: return '\n'; // 'n' -> '\n'
-    case 114: return '\r'; // 'r' -> '\r'
-    case 120: return String.fromCharCode(readHexChar(2)); // 'x'
-    case 117: return readCodePointToString(); // 'u'
-    case 116: return '\t'; // 't' -> '\t'
-    case 98: return '\b'; // 'b' -> '\b'
-    case 118: return '\u000b'; // 'v' -> '\u000b'
-    case 102: return '\f'; // 'f' -> '\f'
-    case 13: if (source.charCodeAt(acornPos) === 10) ++acornPos; // '\r\n'
-    case 10: // ' \n'
-      return '';
-    case 56:
-    case 57:
+  let value = 0;
+  const end = start + length;
+  for (let index = start; index < end; index++) {
+    const char = source.charCodeAt(index);
+    const lower = char | 32;
+    const digit = char >= 48 && char <= 57
+      ? char - 48
+      : lower >= 97 && lower <= 102 ? lower - 87 : -1;
+    if (digit === -1) {
+      acornPos = index;
       syntaxError();
-    default:
-      if (ch >= 48 && ch <= 55) {
-        let octalStr = source.substr(acornPos - 1, 3).match(/^[0-7]+/)[0];
-        let octal = parseInt(octalStr, 8);
-        if (octal > 255) {
-          octalStr = octalStr.slice(0, -1);
-          octal = parseInt(octalStr, 8);
-        }
-        acornPos += octalStr.length - 1;
-        ch = source.charCodeAt(acornPos);
-        if (octalStr !== '0' || ch === 56 || ch === 57)
-          syntaxError();
-        return String.fromCharCode(octal);
-      }
-      if (isBr(ch)) {
-        // Unicode new line characters after \ get removed from output in both
-        // template literals and strings
-        return '';
-      }
-      return String.fromCharCode(ch);
+    }
+    value = value * 16 + digit;
   }
-}
-
-// Used to read character escape sequences ('\x', '\u', '\U').
-
-function readHexChar (len) {
-  const start = acornPos;
-  let total = 0;
-  for (let i = 0; i < len; ++i, ++acornPos) {
-    let code = source.charCodeAt(acornPos), val;
-    if (code >= 97) val = code - 97 + 10; // a
-    else if (code >= 65) val = code - 65 + 10; // A
-    else if (code >= 48 && code <= 57) val = code - 48; // 0-9
-    else break;
-    if (val >= 16) break;
-    total = total * 16 + val;
-  }
-  // len < 1 covers empty and unterminated \u{} escapes
-  if (len < 1 || acornPos - start !== len) syntaxError();
-  return total;
-}
-
-// Read a string value, interpreting backslash-escapes.
-
-function readCodePointToString () {
-  const ch = source.charCodeAt(acornPos);
-  let code;
-  if (ch === 123) { // '{'
-    ++acornPos;
-    const len = source.indexOf('}', acornPos) - acornPos;
-    if (len < 1) syntaxError();
-    code = readHexChar(len);
-    ++acornPos;
-    if (code > 0x10FFFF) syntaxError();
-  } else {
-    code = readHexChar(4);
-  }
-  // UTF-16 Decoding
-  if (code <= 0xFFFF) return String.fromCharCode(code);
-  code -= 0x10000;
-  return String.fromCharCode((code >> 10) + 0xD800, (code & 1023) + 0xDC00);
-}
-
-function isBr (c) {
-  return c === 13/*\r*/ || c === 10/*\n*/;
+  return value;
 }
 
 function syntaxError () {

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -66,9 +66,12 @@ export function parse (_source, _name = '@') {
   while (asm.ri()) {
     const s = asm.is(), e = asm.ie(), importType = asm.it(), t = importType & 15;
     const a = asm.ai(), d = asm.id(), ss = asm.ss(), se = asm.se();
+    const stringFlags = asm.ip();
     let n;
-    if (asm.ip())
+    if (stringFlags === 1/*SafeString*/)
       n = readString(d === -1 ? s : s + 1, d === -1 ? e : e - 1);
+    else if (stringFlags === 3/*SafeString|TemplateRawCR*/)
+      n = readString(d === -1 ? s : s + 1, d === -1 ? e : e - 1, true);
     else if (!MINIMAL && d !== -1 && source.charCodeAt(s) === 96/*`*/)
       n = decodeTemplate(s, e);
     let at = null;
@@ -177,28 +180,32 @@ export function parse (_source, _name = '@') {
  * THE SOFTWARE.
  */
 let acornPos;
+const templateLineEndings = /\r\n?/g;
 /**
  * @param {number} start Start of the string contents.
  * @param {number} end End of the string contents.
+ * @param {boolean} normalizeLineEndings Whether to normalize raw template line endings.
  * @returns {string}
  */
-function readString (start, end) {
-  let escape = source.indexOf('\\', start);
-  if (escape === -1 || escape >= end)
-    return source.slice(start, end);
+function readString (start, end, normalizeLineEndings = false) {
+  const literal = source.slice(start, end);
+  let escape = literal.indexOf('\\');
+  if (escape === -1)
+    return normalizeLineEndings ? literal.replace(templateLineEndings, '\n') : literal;
 
-  let decoded = source.slice(start, escape);
-  while (escape < end) {
+  let chunk = literal.slice(0, escape);
+  let decoded = normalizeLineEndings ? chunk.replace(templateLineEndings, '\n') : chunk;
+  for (;;) {
     let index = escape + 1;
-    if (index >= end) {
-      acornPos = index;
+    if (index >= literal.length) {
+      acornPos = start + index;
       syntaxError();
     }
 
-    const char = source.charCodeAt(index++);
+    const char = literal.charCodeAt(index++);
     switch (char) {
       case 13:
-        if (source.charCodeAt(index) === 10) index++;
+        if (literal.charCodeAt(index) === 10) index++;
         break;
       case 10:
       case 0x2028:
@@ -211,26 +218,26 @@ function readString (start, end) {
       case 102: decoded += '\f'; break;
       case 118: decoded += '\u000b'; break;
       case 120:
-        decoded += String.fromCharCode(readHex(index, 2));
+        decoded += String.fromCharCode(readHex(start + index, 2));
         index += 2;
         break;
       case 117: {
         let codePoint;
-        if (source.charCodeAt(index) === 123) {
-          const close = source.indexOf('}', ++index);
-          if (close === -1 || close >= end) {
-            acornPos = index;
+        if (literal.charCodeAt(index) === 123) {
+          const close = literal.indexOf('}', ++index);
+          if (close === -1) {
+            acornPos = start + index;
             syntaxError();
           }
-          codePoint = readHex(index, close - index);
+          codePoint = readHex(start + index, close - index);
           index = close + 1;
         }
         else {
-          codePoint = readHex(index, 4);
+          codePoint = readHex(start + index, 4);
           index += 4;
         }
         if (codePoint > 0x10ffff) {
-          acornPos = index;
+          acornPos = start + index;
           syntaxError();
         }
         if (codePoint <= 0xffff) {
@@ -243,9 +250,9 @@ function readString (start, end) {
         break;
       }
       case 48: {
-        const next = source.charCodeAt(index);
+        const next = literal.charCodeAt(index);
         if (next >= 48 && next <= 57) {
-          acornPos = index;
+          acornPos = start + index;
           syntaxError();
         }
         decoded += '\0';
@@ -253,19 +260,21 @@ function readString (start, end) {
       }
       default:
         if (char >= 49 && char <= 57) {
-          acornPos = index - 1;
+          acornPos = start + index - 1;
           syntaxError();
         }
         decoded += String.fromCharCode(char);
     }
 
-    const nextEscape = source.indexOf('\\', index);
-    if (nextEscape === -1 || nextEscape >= end)
-      return decoded + source.slice(index, end);
-    decoded += source.slice(index, nextEscape);
+    const nextEscape = literal.indexOf('\\', index);
+    if (nextEscape === -1) {
+      chunk = literal.slice(index);
+      return decoded + (normalizeLineEndings ? chunk.replace(templateLineEndings, '\n') : chunk);
+    }
+    chunk = literal.slice(index, nextEscape);
+    decoded += normalizeLineEndings ? chunk.replace(templateLineEndings, '\n') : chunk;
     escape = nextEscape;
   }
-  return decoded;
 }
 
 // Glob for a lone interpolated-template specifier starting at `s`. The parser

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -26,6 +26,7 @@
 #define TEMPLATE_SIMD_THRESHOLD 16
 static uint32_t template_scan_count;
 #endif
+static bool template_raw_cr;
 
 // Keep the keyword tails in one object so the fastcomp memory image is
 // contiguous and build/gen-asm-in.mjs can extract it without spanning gaps.
@@ -840,6 +841,8 @@ void tryParseImportStatement () {
       // safe specifier exactly like a quoted one. An interpolated template
       // leaves noSubstitutionTemplate() false and falls through to the open-
       // token machinery, which records the import as unsafe (n stays unset).
+      if (template_raw_cr)
+        import_write_head->string_flags |= TemplateRawCR;
     }
     else {
       pos--;
@@ -853,14 +856,14 @@ void tryParseImportStatement () {
       ch = commentWhitespace(true);
       import_write_head->end = endPos;
       import_write_head->attr_index = pos;
-      import_write_head->safe = true;
+      import_write_head->string_flags |= SafeString;
       pos--;
     }
     else if (ch == ')') {
       openTokenDepth--;
       import_write_head->end = endPos;
       import_write_head->statement_end = pos + 1;
-      import_write_head->safe = true;
+      import_write_head->string_flags |= SafeString;
 #ifdef LEX_TS
       classifyDynamicImportMember(import_write_head);
 #endif
@@ -2626,6 +2629,24 @@ static char16_t* simdTemplateScan (char16_t* p) {
   }
 }
 
+LEXER_SIMD_TARGET __attribute__((noinline))
+static char16_t* simdNoSubstitutionTemplateScan (char16_t* p) {
+  const v128_t dollar = wasm_i16x8_splat('$');
+  const v128_t backtick = wasm_i16x8_splat('`');
+  // The range check replaces the null-sentinel equality, so CR tracking adds no SIMD instruction.
+  const v128_t control_limit = wasm_i16x8_splat('\r' + 1);
+  const v128_t slash = wasm_i16x8_splat('\\');
+  for (;;) {
+    v128_t chunk = wasm_v128_load(p);
+    uint32_t mask = wasm_i8x16_bitmask(wasm_v128_or(
+        wasm_v128_or(wasm_i16x8_eq(chunk, dollar), wasm_i16x8_eq(chunk, backtick)),
+        wasm_v128_or(wasm_i16x8_eq(chunk, slash), wasm_u16x8_lt(chunk, control_limit))));
+    if (mask)
+      return p + __builtin_ctz(mask) / 2;
+    p += 8;
+  }
+}
+
 #endif
 
 static inline __attribute__((always_inline)) void templateStringScalar () {
@@ -2730,6 +2751,7 @@ void templateString () {
 // to the main loop's template handling.
 static inline __attribute__((always_inline)) bool noSubstitutionTemplateScalar () {
   char16_t* startPos = pos;
+  template_raw_cr = false;
   while (pos++ < end) {
     char16_t ch = *pos;
     if (ch == '`')
@@ -2738,6 +2760,8 @@ static inline __attribute__((always_inline)) bool noSubstitutionTemplateScalar (
       pos++;
       continue;
     }
+    if (ch == '\r')
+      template_raw_cr = true;
     if (ch == '$' && *(pos + 1) == '{')
       break;
   }
@@ -2747,6 +2771,7 @@ static inline __attribute__((always_inline)) bool noSubstitutionTemplateScalar (
 
 #ifdef LEXER_SIMD
 bool noSubstitutionTemplate () {
+  template_raw_cr = false;
   if (template_scan_count < TEMPLATE_SIMD_THRESHOLD) {
     template_scan_count++;
     return noSubstitutionTemplateScalar();
@@ -2756,10 +2781,10 @@ bool noSubstitutionTemplate () {
     char16_t next_ch = *(p + 1);
     if (next_ch == '`')
       p++;
-    else if (next_ch != '\\' && *(p + 2) == '`')
+    else if (next_ch != '\\' && next_ch != '\r' && *(p + 2) == '`')
       p += 2;
     else
-      p = simdTemplateScan(p + 1);
+      p = simdNoSubstitutionTemplateScan(p + 1);
     char16_t ch = *p;
     if (ch == '`') {
       pos = p;
@@ -2769,6 +2794,10 @@ bool noSubstitutionTemplate () {
       p++;
       if (p > end)
         return false;
+      continue;
+    }
+    if (ch == '\r') {
+      template_raw_cr = true;
       continue;
     }
     if (ch == '$') {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -24,6 +24,11 @@ enum ImportType {
   StaticReexportStar = 8,
 };
 
+enum ImportStringFlags {
+  SafeString = 1,
+  TemplateRawCR = 2,
+};
+
 #ifndef LEXER_MIN
 enum ExportType {
   Direct = 1,
@@ -76,7 +81,7 @@ struct Import {
   const char16_t* statement_end;
   const char16_t* attr_index;
   const char16_t* dynamic;
-  bool safe;
+  uint8_t string_flags;
 #ifdef LEX_TS
   bool type_only;
   bool type_value_certain;
@@ -279,7 +284,7 @@ void addImport (const char16_t* statement_start, const char16_t* start, const ch
   import->end = end;
   import->attr_index = 0;
   import->dynamic = dynamic;
-  import->safe = dynamic == STANDARD_IMPORT;
+  import->string_flags = dynamic == STANDARD_IMPORT ? SafeString : 0;
 #ifdef LEX_TS
   import->type_only = false;
   import->type_value_certain = false;
@@ -368,9 +373,9 @@ uint32_t id () {
     return -2;
   return import_read_head->dynamic - source;
 }
-// getImportSafeString
+// getImportStringFlags
 uint32_t ip () {
-  return import_read_head->safe;
+  return import_read_head->string_flags;
 }
 
 #ifndef LEXER_MIN

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -50,6 +50,11 @@ export enum ImportType {
   StaticReexportStar = 8,
 }
 
+const enum ImportStringFlags {
+  Safe = 1,
+  TemplateRawCR = 2,
+}
+
 /**
  * Import phase modifier: `import source` / `import.source(...)` report
  * `'source'`, `import defer` / `import.defer(...)` report `'defer'`, all
@@ -329,27 +334,28 @@ export interface ParseError extends Error {
 }
 
 const isLE = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+const templateLineEndings = /\r\n?/g;
 
 /**
- * @param source Source containing a validated JavaScript string literal.
- * @param start Start of the string contents.
- * @param end End of the string contents.
+ * @param literal Contents of a validated JavaScript string literal.
+ * @param normalizeLineEndings Whether to normalize raw template line endings.
  */
-function decodeStringLiteral (source: string, start: number, end: number): string {
-  let escape = source.indexOf('\\', start);
-  if (escape === -1 || escape >= end)
-    return source.slice(start, end);
+function decodeStringLiteral (literal: string, normalizeLineEndings: boolean): string {
+  let escape = literal.indexOf('\\');
+  if (escape === -1)
+    return normalizeLineEndings ? literal.replace(templateLineEndings, '\n') : literal;
 
-  let decoded = source.slice(start, escape);
-  while (escape < end) {
+  let chunk = literal.slice(0, escape);
+  let decoded = normalizeLineEndings ? chunk.replace(templateLineEndings, '\n') : chunk;
+  for (;;) {
     let index = escape + 1;
-    if (index >= end)
+    if (index >= literal.length)
       throw new SyntaxError();
 
-    const char = source.charCodeAt(index++);
+    const char = literal.charCodeAt(index++);
     switch (char) {
       case 13:
-        if (source.charCodeAt(index) === 10) index++;
+        if (literal.charCodeAt(index) === 10) index++;
         break;
       case 10:
       case 0x2028:
@@ -362,20 +368,20 @@ function decodeStringLiteral (source: string, start: number, end: number): strin
       case 102: decoded += '\f'; break;
       case 118: decoded += '\u000b'; break;
       case 120:
-        decoded += String.fromCharCode(readHex(source, index, 2));
+        decoded += String.fromCharCode(readHex(literal, index, 2));
         index += 2;
         break;
       case 117: {
         let codePoint;
-        if (source.charCodeAt(index) === 123) {
-          const close = source.indexOf('}', ++index);
-          if (close === -1 || close >= end)
+        if (literal.charCodeAt(index) === 123) {
+          const close = literal.indexOf('}', ++index);
+          if (close === -1)
             throw new SyntaxError();
-          codePoint = readHex(source, index, close - index);
+          codePoint = readHex(literal, index, close - index);
           index = close + 1;
         }
         else {
-          codePoint = readHex(source, index, 4);
+          codePoint = readHex(literal, index, 4);
           index += 4;
         }
         if (codePoint > 0x10ffff)
@@ -390,7 +396,7 @@ function decodeStringLiteral (source: string, start: number, end: number): strin
         break;
       }
       case 48: {
-        const next = source.charCodeAt(index);
+        const next = literal.charCodeAt(index);
         if (next >= 48 && next <= 57)
           throw new SyntaxError();
         decoded += '\0';
@@ -402,13 +408,15 @@ function decodeStringLiteral (source: string, start: number, end: number): strin
         decoded += String.fromCharCode(char);
     }
 
-    const nextEscape = source.indexOf('\\', index);
-    if (nextEscape === -1 || nextEscape >= end)
-      return decoded + source.slice(index, end);
-    decoded += source.slice(index, nextEscape);
+    const nextEscape = literal.indexOf('\\', index);
+    if (nextEscape === -1) {
+      chunk = literal.slice(index);
+      return decoded + (normalizeLineEndings ? chunk.replace(templateLineEndings, '\n') : chunk);
+    }
+    chunk = literal.slice(index, nextEscape);
+    decoded += normalizeLineEndings ? chunk.replace(templateLineEndings, '\n') : chunk;
     escape = nextEscape;
   }
-  return decoded;
 }
 
 /**
@@ -477,9 +485,12 @@ export function parse (source: string, name = '@'): readonly [
   while (wasm.ri()) {
     const s = wasm.is(), e = wasm.ie(), importType = wasm.it(), t = importType & 15;
     const a = wasm.ai(), d = wasm.id(), ss = wasm.ss(), se = wasm.se();
+    const stringFlags = wasm.ip();
     let n;
-    if (wasm.ip())
+    if (stringFlags === ImportStringFlags.Safe)
       n = decode(d === -1 ? s : s + 1, d === -1 ? e : e - 1, s);
+    else if (stringFlags === (ImportStringFlags.Safe | ImportStringFlags.TemplateRawCR))
+      n = decode(d === -1 ? s : s + 1, d === -1 ? e : e - 1, s, true);
     else if (!MINIMAL && d !== -1 && source[s] === '`')
       n = decodeTemplate(s, e);
     let at: Array<[string, string]> | null = null;
@@ -565,9 +576,15 @@ export function parse (source: string, name = '@'): readonly [
     exportPtr = wasm.re();
   }
 
-  function decode (start: number, end: number, idx: number): string {
+  /**
+   * @param start Start of the string contents.
+   * @param end End of the string contents.
+   * @param idx Index to report for invalid escapes.
+   * @param normalizeLineEndings Whether to normalize raw template line endings.
+   */
+  function decode (start: number, end: number, idx: number, normalizeLineEndings = false): string {
     try {
-      return decodeStringLiteral(source, start, end)
+      return decodeStringLiteral(source.slice(start, end), normalizeLineEndings)
     }
     catch (e) {
       throw Object.assign(new Error(`Parse error ${name}:${source.slice(0, idx).split('\n').length}:${idx - source.lastIndexOf('\n', idx - 1)}`), { idx });
@@ -668,7 +685,7 @@ let wasm: {
   id(): number;
   /** getImportEnd */
   ie(): number;
-  /** getImportSafeString */
+  /** getImportStringFlags */
   ip(): number;
   /** getImportStart */
   is(): number;

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -331,12 +331,108 @@ export interface ParseError extends Error {
 const isLE = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
 
 /**
- * Direct eval inherits strict mode and uses the matching V8 compilation-cache key.
- * @param literal Quoted JavaScript string literal.
+ * @param source Source containing a validated JavaScript string literal.
+ * @param start Start of the string contents.
+ * @param end End of the string contents.
  */
-function decodeStringLiteral (literal: string): string {
-  'use strict'
-  return eval(literal)
+function decodeStringLiteral (source: string, start: number, end: number): string {
+  let escape = source.indexOf('\\', start);
+  if (escape === -1 || escape >= end)
+    return source.slice(start, end);
+
+  let decoded = source.slice(start, escape);
+  while (escape < end) {
+    let index = escape + 1;
+    if (index >= end)
+      throw new SyntaxError();
+
+    const char = source.charCodeAt(index++);
+    switch (char) {
+      case 13:
+        if (source.charCodeAt(index) === 10) index++;
+        break;
+      case 10:
+      case 0x2028:
+      case 0x2029:
+        break;
+      case 114: decoded += '\r'; break;
+      case 110: decoded += '\n'; break;
+      case 116: decoded += '\t'; break;
+      case 98: decoded += '\b'; break;
+      case 102: decoded += '\f'; break;
+      case 118: decoded += '\u000b'; break;
+      case 120:
+        decoded += String.fromCharCode(readHex(source, index, 2));
+        index += 2;
+        break;
+      case 117: {
+        let codePoint;
+        if (source.charCodeAt(index) === 123) {
+          const close = source.indexOf('}', ++index);
+          if (close === -1 || close >= end)
+            throw new SyntaxError();
+          codePoint = readHex(source, index, close - index);
+          index = close + 1;
+        }
+        else {
+          codePoint = readHex(source, index, 4);
+          index += 4;
+        }
+        if (codePoint > 0x10ffff)
+          throw new SyntaxError();
+        if (codePoint <= 0xffff) {
+          decoded += String.fromCharCode(codePoint);
+        }
+        else {
+          codePoint -= 0x10000;
+          decoded += String.fromCharCode((codePoint >> 10) + 0xd800, (codePoint & 1023) + 0xdc00);
+        }
+        break;
+      }
+      case 48: {
+        const next = source.charCodeAt(index);
+        if (next >= 48 && next <= 57)
+          throw new SyntaxError();
+        decoded += '\0';
+        break;
+      }
+      default:
+        if (char >= 49 && char <= 57)
+          throw new SyntaxError();
+        decoded += String.fromCharCode(char);
+    }
+
+    const nextEscape = source.indexOf('\\', index);
+    if (nextEscape === -1 || nextEscape >= end)
+      return decoded + source.slice(index, end);
+    decoded += source.slice(index, nextEscape);
+    escape = nextEscape;
+  }
+  return decoded;
+}
+
+/**
+ * @param source Source containing hexadecimal digits.
+ * @param start Start of the hexadecimal digits.
+ * @param length Number of hexadecimal digits.
+ */
+function readHex (source: string, start: number, length: number): number {
+  if (length < 1 || start + length > source.length)
+    throw new SyntaxError();
+
+  let value = 0;
+  const end = start + length;
+  for (let index = start; index < end; index++) {
+    const char = source.charCodeAt(index);
+    const lower = char | 32;
+    const digit = char >= 48 && char <= 57
+      ? char - 48
+      : lower >= 97 && lower <= 102 ? lower - 87 : -1;
+    if (digit === -1)
+      throw new SyntaxError();
+    value = value * 16 + digit;
+  }
+  return value;
 }
 
 /**
@@ -383,7 +479,7 @@ export function parse (source: string, name = '@'): readonly [
     const a = wasm.ai(), d = wasm.id(), ss = wasm.ss(), se = wasm.se();
     let n;
     if (wasm.ip())
-      n = decode(source.slice(d === -1 ? s - 1 : s, d === -1 ? e + 1 : e), s);
+      n = decode(d === -1 ? s : s + 1, d === -1 ? e : e - 1, s);
     else if (!MINIMAL && d !== -1 && source[s] === '`')
       n = decodeTemplate(s, e);
     let at: Array<[string, string]> | null = null;
@@ -394,7 +490,7 @@ export function parse (source: string, name = '@'): readonly [
       wasm.rsa();
       while (wasm.ra()) {
         const aks = wasm.aks(), ake = wasm.ake(), avs = wasm.avs(), ave = wasm.ave();
-        at.push([decodeIfQuoted(source.slice(aks, ake), aks), decodeIfQuoted(source.slice(avs, ave), avs)]);
+        at.push([decodeIfQuoted(aks, ake), decodeIfQuoted(avs, ave)]);
       }
       if (at.length === 0) at = null;
     }
@@ -418,8 +514,8 @@ export function parse (source: string, name = '@'): readonly [
   while (exportPtr !== 0) {
     if (MINIMAL) {
       const s = wasm.es(), e = wasm.ee(), ls = wasm.els(), le = wasm.ele();
-      const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le), ls);
-      const n = decodeIfQuoted(source.slice(s, e), s);
+      const ln = ls < 0 ? undefined : decodeIfQuoted(ls, le);
+      const n = decodeIfQuoted(s, e);
       exports.push({ s, e, ls, le, n, ln } as unknown as Export);
       exportPtr = wasm.re();
       continue;
@@ -441,15 +537,15 @@ export function parse (source: string, name = '@'): readonly [
       exports.push({ type: 'reexport-all', from: (imports[fi] as StaticImport).specifier, importIndex: fi, start: s, end: e, exportStart: ss, typeOnly: tp });
     }
     else {
-      const n = decodeIfQuoted(source.slice(s, e), s);
+      const n = decodeIfQuoted(s, e);
       if (t === ExportType.Direct) {
-        const ln = ls < 0 ? undefined : decodeIfQuoted(source.slice(ls, le), ls);
+        const ln = ls < 0 ? undefined : decodeIfQuoted(ls, le);
         exports.push({ type: 'direct', name: n, localName: ln, start: s, end: e, localStart: ls, localEnd: le, exportStart: ss, typeOnly: tp });
       }
       else {
         const nameType = importNameType & 3;
         const im = nameType === 0
-          ? decodeIfQuoted(source.slice(ls, le), ls)
+          ? decodeIfQuoted(ls, le)
           : nameType === 1 ? 'default' : null;
         exports.push({
           type: 'reexport',
@@ -469,20 +565,20 @@ export function parse (source: string, name = '@'): readonly [
     exportPtr = wasm.re();
   }
 
-  function decode (str: string, idx: number): string {
+  function decode (start: number, end: number, idx: number): string {
     try {
-      return decodeStringLiteral(str)
+      return decodeStringLiteral(source, start, end)
     }
     catch (e) {
       throw Object.assign(new Error(`Parse error ${name}:${source.slice(0, idx).split('\n').length}:${idx - source.lastIndexOf('\n', idx - 1)}`), { idx });
     }
   }
 
-  function decodeIfQuoted (str: string, idx: number): string {
-    const firstChar = str[0];
-    if (firstChar === '"' || firstChar === "'")
-      return decode(str, idx);
-    return str;
+  function decodeIfQuoted (start: number, end: number): string {
+    const firstChar = source.charCodeAt(start);
+    if (firstChar === 34 || firstChar === 39)
+      return decode(start + 1, end - 1, start);
+    return source.slice(start, end);
   }
 
   // Glob for a lone interpolated-template specifier starting at `s`. The parser

--- a/test/no-eval/index.cjs
+++ b/test/no-eval/index.cjs
@@ -22,12 +22,40 @@ suite('No string code generation', () => {
       ["import 'line\\\ncontinuation'", 'linecontinuation'],
       [String.raw`import 'nul\0character'`, 'nul\0character'],
       [String.raw`import 'quote\''`, "quote'"],
+      ["import(`raw\rreturn`)", 'raw\nreturn'],
+      ["import(`raw\r\nreturn`)", 'raw\nreturn'],
+      ["import(`raw\rreturn\\tvalue`)", 'raw\nreturn\tvalue'],
+      ["import(`raw\rreturn`, { with: { type: 'json' } })", 'raw\nreturn'],
+      ["import(`escaped\\rreturn`)", 'escaped\rreturn'],
     ];
 
     for (const [source, expected] of cases) {
       const [imports] = parse(source);
       assert.strictEqual(minimal ? imports[0].n : imports[0].specifier, expected);
     }
+  });
+
+  test('decodes export names', () => {
+    const source = String.raw`export { "escaped\u002dimport" as "escaped\u002dname" } from 'plain-specifier'`;
+    const [, exports] = parse(source);
+    const exported = exports[0];
+
+    assert.strictEqual(minimal ? exported.n : exported.name, 'escaped-name');
+    if (!minimal) {
+      assert.strictEqual(exported.importName, 'escaped-import');
+    }
+  });
+
+  test('normalizes template line endings after SIMD warmup', () => {
+    for (let index = 0; index < 20; index++) {
+      parse(`import(\`specifier-${index}\`)`);
+    }
+
+    const [imports] = parse("import(`raw\rreturn`)");
+    assert.strictEqual(minimal ? imports[0].n : imports[0].specifier, 'raw\nreturn');
+
+    const [unsafeImports] = parse("import(`raw\rreturn` + suffix)");
+    assert.strictEqual(minimal ? unsafeImports[0].n : unsafeImports[0].specifier, undefined);
   });
 
   test('rejects invalid module strings', () => {

--- a/test/no-eval/index.cjs
+++ b/test/no-eval/index.cjs
@@ -7,7 +7,7 @@ const minimal = !!process.env.MINIMAL;
 suite('No string code generation', () => {
   suiteSetup(async () => {
     const lexer = commonjs
-      ? require('../../dist/lexer.cjs')
+      ? require(minimal ? '../../dist/lexer.minimal.cjs' : '../../dist/lexer.cjs')
       : await import(minimal ? '../../dist/lexer.minimal.js' : '../../dist/lexer.js');
     await lexer.init;
     parse = lexer.parse;

--- a/test/no-eval/index.cjs
+++ b/test/no-eval/index.cjs
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+
+let parse;
+const commonjs = !!process.env.CJS;
+const minimal = !!process.env.MINIMAL;
+
+suite('No string code generation', () => {
+  suiteSetup(async () => {
+    const lexer = commonjs
+      ? require('../../dist/lexer.cjs')
+      : await import(minimal ? '../../dist/lexer.minimal.js' : '../../dist/lexer.js');
+    await lexer.init;
+    parse = lexer.parse;
+  });
+
+  test('decodes module strings', () => {
+    const cases = [
+      [`import 'plain-specifier'`, 'plain-specifier'],
+      [String.raw`import 'escaped\u002dspecifier'`, 'escaped-specifier'],
+      [String.raw`import 'escaped\x2dspecifier'`, 'escaped-specifier'],
+      [String.raw`import 'unicode\u{20204}'`, 'unicode𠈄'],
+      ["import 'line\\\ncontinuation'", 'linecontinuation'],
+      [String.raw`import 'nul\0character'`, 'nul\0character'],
+      [String.raw`import 'quote\''`, "quote'"],
+    ];
+
+    for (const [source, expected] of cases) {
+      const [imports] = parse(source);
+      assert.strictEqual(minimal ? imports[0].n : imports[0].specifier, expected);
+    }
+  });
+
+  test('rejects invalid module strings', () => {
+    for (const source of [
+      String.raw`import 'invalid\uZZ'`,
+      String.raw`import 'invalid\u{}'`,
+      String.raw`import 'invalid\u{110000}'`,
+      String.raw`import 'invalid\01'`,
+      String.raw`import 'invalid\8'`,
+    ]) {
+      assert.throws(() => parse(source), { message: /^Parse error / });
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #220.

Direct `eval` decoded quoted import and export names. This prevented parsing when an environment disabled string code generation.

The replacement decoder returns literals without escapes directly. It decodes JavaScript string escapes without compiling source. Each backslash search stops at the literal boundary, which avoids quadratic work across modules with many records.

No-substitution template imports require raw CR and CRLF normalization. The lexer records raw CR in safe templates, so only that uncommon path normalizes the result.

## Performance

The repository benchmark suite parses eight Angular, D3, Magic String, and Rollup files totaling 3,057,186 bytes.

I ran it on Node.js 24.20.0 / V8 13.6.233.17-node.53 after 100,000 warmup calls. Each trial ran 200 complete suite passes. The mean excludes the fastest and slowest of seven trials.

| Process | Before | After | Change |
| --- | ---: | ---: | ---: |
| First | 7.065 ms | 6.965 ms | -1.42% |
| Fresh process, reversed load order | 7.125 ms | 7.142 ms | +0.24% |

The direction did not reproduce, so the complete real-world suite is unchanged within noise.

Repeated parsing of a synthetic specifier with 1,024 `\x61` escapes regressed from 7.14 µs to 17.11 µs. V8 can cache compilation of the repeated string, while the scanner decodes every escape each time.

## Correctness

The decoder matched `eval` for 420,835 cases on Node.js 18 and 24. The corpus covers one-code-unit escapes, Unicode escapes, malformed input, and escape combinations.

The no-eval matrix covers full and minimal ESM and CommonJS builds on Node.js 18.20.8 and 24.20.0. Each row loads its published bundle. Raw CR and CRLF normalization runs on scalar and SIMD paths.

The local fastcomp layout was unavailable, so I syntax-checked the mirrored asm source but did not execute its complete build.
