### PR TITLE
fix: bare declare erasure end conditions

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1198,6 +1198,14 @@ bool skipTsBalanced () {
 // Scans declaration heritage or a module name through its body and skips the
 // body opaquely. Entry: pos AT ch. Exit: pos AT the char after the body.
 static void skipTsDeclarationBody (char16_t ch) {
+  // `module 'name'` has no body unless a `{` follows.
+  if (isQuote(ch)) {
+    stringLiteral(ch);
+    pos++;
+    if (commentWhitespace(true) == '{')
+      skipTsBalanced();
+    return;
+  }
   while (pos < end && ch != '{' && ch != ';') {
     if (ch == '<' || ch == '(' || ch == '[') {
       if (!skipTsBalanced())
@@ -1531,7 +1539,8 @@ void tsAmbientExportDeclaration () {
   pos--;
 }
 
-// pos AT the keyword following `declare`.
+// pos AT the keyword following `declare`. The separator check keeps a class
+// field named after a keyword (`declare type: T`) a field.
 static bool isTsAmbientDeclarationKeyword (char16_t ch) {
   switch (ch) {
     case 'a': return memcmp(pos, ABSTRACT, 8 * 2) == 0 && isTsKeywordSeparator(*(pos + 8));
@@ -1575,12 +1584,17 @@ bool tryTsAmbientDeclaration () {
       skipTsDeclarationBody(ch);
     }
     else {
-      if (isTsIdentifierStart(ch))
+      bool named = isTsIdentifierStart(ch);
+      if (named)
         readToWsOrPunctuator(ch);
-      skipTsErasedTail(true, false);
+      skipTsErasedTail(!named, false);
     }
   }
   else {
+    if (ch == 'm') {
+      pos += 6;
+      ch = commentWhitespace(true);
+    }
     skipTsDeclarationBody(ch);
   }
   pos--;
@@ -1892,14 +1906,23 @@ bool tryParseExportStatement () {
         bool localName = false;
         switch (ch) {
 #ifdef LEX_TS
-          case 'i':
-            // `export default interface Foo {}`: a type-only default export.
-            if (tryTsTypeDeclaration(true)) {
-              addExport(startPos, startPos + 7, NULL, NULL);
-              export_write_head->import_name_ty |= TYPE_ONLY_EXPORT;
+          case 'i': {
+            // `export default interface Foo {}`: a type-only default export
+            // with the interface name as its local name.
+            Export* prev = export_write_head;
+            if (tryTsTypeDeclaration(false)) {
+              if (export_write_head != prev) {
+                export_write_head->start = startPos;
+                export_write_head->end = startPos + 7;
+              }
+              else {
+                addExport(startPos, startPos + 7, NULL, NULL);
+                export_write_head->import_name_ty |= TYPE_ONLY_EXPORT;
+              }
               return true;
             }
             break;
+          }
 #endif
           // export default async? function*? name? (){}
           case 'a':

--- a/test/fuzz-ts.mjs
+++ b/test/fuzz-ts.mjs
@@ -223,6 +223,8 @@ function bareAmbientDeclaration () {
   return pick([
     () => `declare${sameLine}const${gap}fuzzAmbient: import('${ERASED_SPECIFIER}').Value;`,
     () => `declare${sameLine}let${gap}fuzzAmbient: number, fuzzOther: import('${ERASED_SPECIFIER}').Value;`,
+    () => `declare${sameLine}let${gap}fuzzAmbient`,
+    () => `declare${sameLine}module${gap}'fuzz-shorthand'`,
     () => `declare${sameLine}function${gap}fuzzAmbient(value: import('${ERASED_SPECIFIER}').Value): void;`,
     () => `declare${sameLine}class${gap}FuzzAmbient extends Base { value: import('${ERASED_SPECIFIER}').Value }`,
     () => `declare${sameLine}abstract${gap}class${gap}FuzzAmbient { value: import('${ERASED_SPECIFIER}').Value }`,

--- a/test/typescript/type-declarations.cjs
+++ b/test/typescript/type-declarations.cjs
@@ -595,6 +595,7 @@ export const y = 1;`;
     const [imports, exports] = parse(`export default interface Foo { x: import('m').T }\nexport const y = 1;`);
     assert.deepStrictEqual(imports.map(i => i.n), []);
     assert.deepStrictEqual(exports.map(e => e.n), ['default', 'y']);
+    assert.deepStrictEqual(exports.map(e => e.ln), ['Foo', 'y']);
     assert.deepStrictEqual(exports.map(e => e.tp), [true, false]);
   });
 
@@ -613,12 +614,24 @@ export const y = 1;`;
       `declare module 'm' { export const x: import('n').T; export default x; }`,
       `declare global { interface Window { x: import('m').T } }`,
       `declare type T = import('m').T;`,
-      `declare interface I { x: import('m').T }`
+      `declare interface I { x: import('m').T }`,
+      `declare let a`,
+      `declare var v`,
+      `declare const x = 1`,
+      `declare function f(): void`,
+      `declare module 'm'`,
+      `declare module 'm'\n{ export const x: import('n').T }`
     ]) {
       const [imports, exports] = parse(source + `\nimport 'runtime';\nexport const y = 1;`);
       assert.deepStrictEqual(imports.map(i => i.n), ['runtime'], source);
       assert.deepStrictEqual(exports.map(e => e.n), ['y'], source);
     }
+  });
+
+  test('shorthand export declare module ends at the line break', () => {
+    const [imports, exports] = parse(`export declare module 'm'\nimport 'runtime';`);
+    assert.deepStrictEqual(imports.map(i => i.n), ['runtime']);
+    assert.deepStrictEqual(exports.map(e => e.n), []);
   });
 
   test('declare as a plain identifier stays runtime', () => {


### PR DESCRIPTION
This fixes two erasure regressions from the bare `declare` handling in #220 and one record inconsistency.

A bare ambient declaration is erased whole, but two forms ran past their own statement under ASI and swallowed the following code:

* An unannotated `declare let a` / `declare var v` ended by a line break left the operand pending after the binding name, so the next statement was erased too. The name now satisfies the operand.
* Shorthand `declare module 'm'` without a semicolon scanned ahead to the next `{` anywhere in the file. This also affected `export declare module 'm'`. A string-named module now ends at its statement unless a `{` body follows.
* `export default interface Foo {}` reports `localName: 'Foo'`, matching `export default class Foo {}`.

```ts
declare let a
import 'runtime'     // before: imports [] — after: ['runtime']

declare module 'm'
import 'runtime'     // before: imports [] — after: ['runtime']
```

Tests cover the unannotated binding, `const = literal`, function signature and shorthand module forms under ASI (bare and `export declare`), a shorthand module with a body on the next line, and the default interface local name; the fuzz forms gain the unannotated binding and shorthand module.