### PR TITLE
perf: copy short sources with the charCodeAt loop

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -334,6 +334,7 @@ export interface ParseError extends Error {
 }
 
 const isLE = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+const hasBuffer = typeof Buffer !== 'undefined';
 const templateLineEndings = /\r\n?/g;
 
 /**
@@ -473,7 +474,8 @@ export function parse (source: string, name = '@'): readonly [
   const addr = wasm.sa(len - 1);
   // Node's Buffer blits UTF-16 straight into Wasm memory ~10x faster than the
   // charCodeAt fallback, in explicit LE matching Wasm regardless of host.
-  if (typeof Buffer !== 'undefined')
+  // Buffer setup is slower than the loop for short sources.
+  if (source.length >= 64 && hasBuffer)
     Buffer.from(wasm.memory.buffer, addr, (len - 1) * 2).write(source, 'utf16le');
   else
     (isLE ? copyLE : copyBE)(source, new Uint16Array(wasm.memory.buffer, addr, len));


### PR DESCRIPTION
This routes sources under 64 characters through the typed-array `charCodeAt` copy instead of `Buffer.from(...).write(..., 'utf16le')`.

The Buffer blit wins clearly for real module sources, but constructing the Buffer view costs more than the loop itself for very short inputs, which show up in practice as tiny inline modules and in per-call benchmarks.

* `source.length >= 64` gates the Buffer path; shorter sources use `copyLE` / `copyBE`.
* The `typeof Buffer` check is hoisted to a module-level `hasBuffer`.

Applies to both the full and minimal wasm builds (shared `lexer.ts`); the asm.js wrapper has its own copy and is unchanged. Existing tests exercise both sides of the threshold.