### PR TITLE
fix: bounds check the token stacks and verify the source terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,10 @@ The full build requires Node.js 18+ and engines with [WebAssembly SIMD support](
 
 The minimal build (`es-module-lexer/minimal`) carries no SIMD requirement, running in all browsers with baseline [ES modules support](https://caniuse.com/es6-module-dynamic-import) (Chrome 63+, Firefox 67+, Safari 11.1+ — the [es-module-shims](https://github.com/guybedford/es-module-shims) support matrix), with the asm.js builds covering those without WebAssembly.
 
+Nesting is bounded: more than 1024 open brackets or template substitutions, or
+more than 512 nested dynamic import calls, throws a parse error at the
+overflowing token.
+
 ### Grammar Support
 
 * Token state parses all line comments, block comments, strings, template strings, blocks, parens and punctuators.

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -418,12 +418,12 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
       goto skipTokenRun;
 #endif
     case '(':
-      openTokenStack[openTokenDepth].token = AnyParen;
-      openTokenStack[openTokenDepth++].pos = lastTokenPos;
+      if (!pushOpenToken(AnyParen, lastTokenPos))
+        return false;
       break;
     case '[':
-      openTokenStack[openTokenDepth].token = AnyBracket;
-      openTokenStack[openTokenDepth++].pos = lastTokenPos;
+      if (!pushOpenToken(AnyBracket, lastTokenPos))
+        return false;
       break;
 #ifdef LEX_TS
     case '<':
@@ -500,8 +500,8 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
         import_count--;
 #endif
       }
-      openTokenStack[openTokenDepth].token = nextBraceIsClass ? ClassBrace : AnyBrace;
-      openTokenStack[openTokenDepth++].pos = lastTokenPos;
+      if (!pushOpenToken(nextBraceIsClass ? ClassBrace : AnyBrace, lastTokenPos))
+        return false;
       nextBraceIsClass = false;
       break;
     case '}':
@@ -579,8 +579,8 @@ static inline __attribute__((always_inline)) bool consumeToken (char16_t ch) {
           dynamicImportStack[dynamicImportStackDepth - 1]->start == pos)
         dynamicImportStack[dynamicImportStackDepth - 1]->specifier_template_depth = openTokenDepth + 1;
 #endif
-      openTokenStack[openTokenDepth].pos = lastTokenPos;
-      openTokenStack[openTokenDepth++].token = Template;
+      if (!pushOpenToken(Template, lastTokenPos))
+        return false;
       templateString();
       break;
     default:
@@ -599,8 +599,8 @@ bool parse () {
   // stack allocations
   // these are done here to avoid data section \0\0\0 repetition bloat
   // (while gzip fixes this, still better to have ~10KiB ungzipped over ~20KiB)
-  OpenToken openTokenStack_[1024];
-  Import* dynamicImportStack_[512];
+  OpenToken openTokenStack_[OPEN_TOKEN_STACK_SIZE];
+  Import* dynamicImportStack_[DYNAMIC_IMPORT_STACK_SIZE];
 
   facade = true;
 #ifndef LEXER_MIN
@@ -820,10 +820,14 @@ void tryParseImportStatement () {
 
   // dynamic import
   if (ch == '(') {
-    openTokenStack[openTokenDepth].token = ImportParen;
-    openTokenStack[openTokenDepth++].pos = pos;
+    if (!pushOpenToken(ImportParen, pos))
+      return;
     if (*lastTokenPos == '.')
       return;
+    if (dynamicImportStackDepth == DYNAMIC_IMPORT_STACK_SIZE) {
+      syntaxError();
+      return;
+    }
     // dynamic import indicated by positive d
     char16_t* dynamicPos = pos;
     // try parse a string, to record a safe dynamic import string
@@ -2725,8 +2729,7 @@ static inline __attribute__((always_inline)) void templateStringScalar () {
     char16_t ch = *pos;
     if (ch == '$' && *(pos + 1) == '{') {
       pos++;
-      openTokenStack[openTokenDepth].token = TemplateBrace;
-      openTokenStack[openTokenDepth++].pos = pos;
+      pushOpenToken(TemplateBrace, pos);
       return;
     }
     if (ch == '`') {
@@ -2773,8 +2776,7 @@ void templateString () {
       if (*(p + 1) != '{')
         continue;
       pos = p + 1;
-      openTokenStack[openTokenDepth].token = TemplateBrace;
-      openTokenStack[openTokenDepth++].pos = pos;
+      pushOpenToken(TemplateBrace, pos);
       return;
     }
     if (ch == '`') {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -578,3 +578,16 @@ void nextCharSurrogate (char16_t ch);
 char16_t readChar ();
 
 void syntaxError ();
+
+#define OPEN_TOKEN_STACK_SIZE 1024
+#define DYNAMIC_IMPORT_STACK_SIZE 512
+
+static inline __attribute__((always_inline)) bool pushOpenToken (enum OpenTokenState token, char16_t* tokenPos) {
+  if (openTokenDepth == OPEN_TOKEN_STACK_SIZE) {
+    syntaxError();
+    return false;
+  }
+  openTokenStack[openTokenDepth].token = token;
+  openTokenStack[openTokenDepth++].pos = tokenPos;
+  return true;
+}

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -2904,4 +2904,41 @@ export { d as a, p as b, z as c, r as d, q }`;
     assert.strictEqual(exports.length, 1);
     assert.strictEqual(exports[0].n, 'x');
   });
+
+  test('Open token stack bounds', () => {
+    for (const [open, close] of [['(', ')'], ['[', ']'], ['{', '}']]) {
+      parse(open.repeat(1024) + close.repeat(1024));
+      assert.throws(() => parse(open.repeat(1025) + close.repeat(1025)), { idx: 1024 });
+    }
+    // each template level holds a Template and a TemplateBrace entry; the 513th
+    // level's backtick is entry 1025
+    parse('`${'.repeat(512) + '1' + '}`'.repeat(512));
+    assert.throws(() => parse('`${'.repeat(513) + '1' + '}`'.repeat(513)), { idx: 513 * 3 - 3 });
+  });
+
+  test('Dynamic import stack bounds', () => {
+    const nest = n => 'import('.repeat(n) + "'a'" + ')'.repeat(n);
+    const [imports] = parse(nest(512));
+    assert.strictEqual(imports.length, 512);
+    assert.throws(() => parse(nest(513)), { idx: 7 * 513 - 1 });
+  });
+
+  test('Embedded null characters do not terminate scanning', () => {
+    const source = `import 'a';\nconst s = "\0" + '\0';\n/* \0 */ // \0\nconst t = \`\0\${1}\0\`;\nimport 'b';\nimport('c');`;
+    const [imports] = parse(source);
+    assert.deepStrictEqual(imports.map(i => i.n), ['a', 'b', 'c']);
+  });
+
+  test('Source terminator survives the copy and parse', async () => {
+    if (process.env.ASM) return;
+    const { instance } = await WebAssembly.instantiate(await readFile(min ? 'lib/lexer.min.wasm' : 'lib/lexer.wasm'));
+    const wasm = instance.exports;
+    const source = `import 'a'; export const b = 1;`;
+    const addr = wasm.sa(source.length);
+    const mem = new Uint16Array(wasm.memory.buffer, addr, source.length + 1);
+    for (let i = 0; i < source.length; i++) mem[i] = source.charCodeAt(i);
+    assert.strictEqual(mem[source.length], 0);
+    assert.strictEqual(wasm.parse(), 1);
+    assert.strictEqual(mem[source.length], 0);
+  });
 });


### PR DESCRIPTION
This adds depth checks to the open token and dynamic import stacks and verifies the source null terminator at the start of every parse.

The two stacks are fixed-size arrays on the wasm stack (1024 open tokens, 512 dynamic imports). Every pop already guarded against underflow, but none of the pushes checked depth, so a source nested past either limit wrote beyond the array.

* All open token pushes go through a checked `pushOpenToken()`; the dynamic import push checks its own depth. Overflow is a parse error at the overflowing token.
* `parse()` verifies the terminator `sa()` placed after the source is still zero, failing at `sourceLen` otherwise, since the sentinel scans are unbounded without it.
* README documents the nesting limits.

Tests cover the 1024/1025 boundary for each bracket kind and template substitution nesting, the 512/513 boundary for nested dynamic imports, embedded null characters in strings, comments and templates, and a raw-wasm check that the terminator survives a parse and that a clobbered terminator fails the parse.