### PR TITLE
chore: update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^8.0.4",
-    "@babel/core": "^8.0.1",
-    "@babel/plugin-transform-modules-commonjs": "^8.0.1",
+    "@babel/cli": "^7.29.7",
+    "@babel/core": "^7.29.7",
+    "@babel/plugin-transform-modules-commonjs": "^7.29.7",
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.16.2",
     "@types/node": "^26.4.1",

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^7.29.7",
-    "@babel/core": "^7.29.7",
-    "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+    "@babel/cli": "^8.0.4",
+    "@babel/core": "^8.0.1",
+    "@babel/plugin-transform-modules-commonjs": "^8.0.1",
     "@swc/cli": "^0.8.1",
-    "@swc/core": "^1.15.41",
-    "@types/node": "^25.9.3",
+    "@swc/core": "^1.16.2",
+    "@types/node": "^26.4.1",
     "kleur": "^4.1.5",
-    "mocha": "^11.7.6",
-    "terser": "^5.48.0",
-    "typescript": "^6.0.3"
+    "mocha": "^11.8.0",
+    "terser": "^5.51.2",
+    "typescript": "^7.0.2"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This updates the devDependencies to their current releases.

* TypeScript 7 — the tracked `types/` declarations regenerate byte-identical.
* `@swc/core` 1.16, `@types/node` 26, `terser` 5.51.
* `mocha` stays on 11.x: 12 requires Node.js 20.19+, above the supported Node.js 18 floor.
* Babel stays on 7.x: 8 requires Node.js 22.18+, and its CLI fails the Node.js 18 lane at build time (`node:util` `styleText`), which left the CommonJS bundles empty.

`chomp test` passes in all lanes with the new toolchain.
