### PR TITLE
feat: glob flag on dynamic imports, specifier and typeOnly on import.meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,13 @@ kind-specific fields: the terse v2 field names and numeric type tags are
 replaced by the descriptive names above, reexports no longer expose
 placeholder local-name properties, and bare star reexports now appear in the
 exports array with their origins available through `importName` and
-`imports[importIndex]` without rescanning source statements.
+`imports[importIndex]` without rescanning source statements. A dynamic
+import whose argument is a template literal now reports a glob `specifier`
+(`./locales/*.js`) where v2 reported `undefined`, so a v2 `if (specifier)`
+check now admits globs; test `glob` to tell them apart (a literal
+`import('a*b')` and a template `\`a${x}b\`` both report `a*b`).
+`import.meta` records carry `specifier: null` and `typeOnly: false` so
+dependency loops need not narrow on `type` first.
 
 ### TypeScript
 
@@ -360,6 +366,8 @@ and does not affect the glob.
 The static parts are the raw specifier source: escape sequences are not
 cooked, and a literal `*` in the specifier is emitted as-is, so a consumer
 treating the glob `specifier` as a pattern has to apply its own escaping.
+Glob records report `glob: true`; a literal specifier that happens to contain
+`*` reports `glob: false`.
 
 ### Star Re-exports
 

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -70,11 +70,13 @@ export function parse (_source, _name = '@') {
     const s = asm.is(), e = asm.ie(), importType = asm.it(), t = importType & 15;
     const a = asm.ai(), d = asm.id(), ss = asm.ss(), se = asm.se();
     const stringFlags = asm.ip();
-    let n;
+    let n, glob = false;
     if (stringFlags & 1/*SafeString*/)
       n = readString(d === -1 ? s : s + 1, d === -1 ? e : e - 1, (stringFlags & 2/*TemplateRawCR*/) !== 0);
-    else if (!MINIMAL && d !== -1 && source.charCodeAt(s) === 96/*`*/)
+    else if (!MINIMAL && d !== -1 && source.charCodeAt(s) === 96/*`*/) {
       n = decodeTemplate(s, e);
+      glob = n !== undefined;
+    }
     let at = null;
     // minimal build drops the parsed attribute list; es-module-shims reads the
     // assertion via source.slice(a, se - 1) instead
@@ -91,11 +93,11 @@ export function parse (_source, _name = '@') {
       imports.push({ t, n, s, e, ss, se, d, a });
     }
     else if (t === 3/*ImportMeta*/) {
-      imports.push({ type: 'import-meta', start: s, end: e, importStart: ss, importEnd: se });
+      imports.push({ type: 'import-meta', specifier: null, typeOnly: false, start: s, end: e, importStart: ss, importEnd: se });
     }
     else if (d !== -1) {
       const phase = t === 5/*DynamicSourcePhase*/ ? 'source' : t === 7/*DynamicDeferPhase*/ ? 'defer' : null;
-      imports.push({ type: 'dynamic', specifier: n, phase, start: s, end: e, importStart: ss, importEnd: se, dynamicStart: d, attributes: null, attributesStart: a, probablyTypeOnly: !!(importType & 16) });
+      imports.push({ type: 'dynamic', specifier: n, glob, phase, start: s, end: e, importStart: ss, importEnd: se, dynamicStart: d, attributes: null, attributesStart: a, probablyTypeOnly: !!(importType & 16) });
     }
     else {
       const phase = t === 4/*StaticSourcePhase*/ ? 'source' : t === 6/*StaticDeferPhase*/ ? 'defer' : null;

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -138,6 +138,11 @@ export interface DynamicImport extends ImportBase {
    * // Returns "./locales/*.js"
    */
   readonly specifier: string | undefined;
+  /**
+   * True when `specifier` is a template glob rather than a literal string,
+   * since `import('a*b')` and `import(\`a${x}b\`)` both report `a*b`.
+   */
+  readonly glob: boolean;
   readonly phase: ImportPhase;
   /**
    * Start of the dynamic import expression argument.
@@ -170,6 +175,10 @@ export interface DynamicImport extends ImportBase {
  */
 export interface ImportMetaRef extends ImportBase {
   readonly type: 'import-meta';
+  /** Always `null`, so dependency loops need not narrow on `type`. */
+  readonly specifier: null;
+  /** Always `false`: an `import.meta` reference is never type-only. */
+  readonly typeOnly: false;
 }
 
 export type Import = StaticImport | DynamicImport | ImportMetaRef;
@@ -472,11 +481,13 @@ export function parse (source: string, name = '@'): readonly [
     const s = wasm.is(), e = wasm.ie(), importType = wasm.it(), t = importType & 15;
     const a = wasm.ai(), d = wasm.id(), ss = wasm.ss(), se = wasm.se();
     const stringFlags = wasm.ip();
-    let n;
+    let n, glob = false;
     if (stringFlags & ImportStringFlags.Safe)
       n = decode(d === -1 ? s : s + 1, d === -1 ? e : e - 1, s, (stringFlags & ImportStringFlags.TemplateRawCR) !== 0);
-    else if (!MINIMAL && d !== -1 && source[s] === '`')
+    else if (!MINIMAL && d !== -1 && source[s] === '`') {
       n = decodeTemplate(s, e);
+      glob = n !== undefined;
+    }
     let at: Array<[string, string]> | null = null;
     // minimal build has no attribute list; es-module-shims reads the assertion
     // via source.slice(a, se - 1) instead
@@ -493,11 +504,11 @@ export function parse (source: string, name = '@'): readonly [
       imports.push({ n, t, s, e, ss, se, d, a } as unknown as Import);
     }
     else if (t === 3/*ImportMeta*/) {
-      imports.push({ type: 'import-meta', start: s, end: e, importStart: ss, importEnd: se });
+      imports.push({ type: 'import-meta', specifier: null, typeOnly: false, start: s, end: e, importStart: ss, importEnd: se });
     }
     else if (d !== -1) {
       const phase: ImportPhase = t === 5/*DynamicSourcePhase*/ ? 'source' : t === 7/*DynamicDeferPhase*/ ? 'defer' : null;
-      imports.push({ type: 'dynamic', specifier: n, phase, start: s, end: e, importStart: ss, importEnd: se, dynamicStart: d, attributes: null, attributesStart: a, probablyTypeOnly: !!(importType & 16) });
+      imports.push({ type: 'dynamic', specifier: n, glob, phase, start: s, end: e, importStart: ss, importEnd: se, dynamicStart: d, attributes: null, attributesStart: a, probablyTypeOnly: !!(importType & 16) });
     }
     else {
       const phase: ImportPhase = t === 4/*StaticSourcePhase*/ ? 'source' : t === 6/*StaticDeferPhase*/ ? 'defer' : null;

--- a/test/full-api.cjs
+++ b/test/full-api.cjs
@@ -65,6 +65,7 @@ suite('Full build API', () => {
     assert.deepStrictEqual(imports, [{
       type: 'dynamic',
       specifier: './x.js',
+      glob: false,
       phase: null,
       start: source.indexOf(`'./x.js'`),
       end: source.indexOf(`'./x.js'`) + 8,
@@ -82,6 +83,12 @@ suite('Full build API', () => {
     const [imports] = parse(source);
     assert.strictEqual(imports[0].type, 'dynamic');
     assert.strictEqual(imports[0].specifier, './locales/*.js');
+    assert.strictEqual(imports[0].glob, true);
+    // a literal star is not a glob, and neither is a substitution-free template
+    for (const literal of ['import("a*b")', 'import(`a*b`)', 'import(`a${x}` + b)']) {
+      const [[record]] = parse(literal);
+      assert.strictEqual(record.glob, false, literal);
+    }
   });
 
   test('import.meta', () => {
@@ -89,6 +96,8 @@ suite('Full build API', () => {
     const [imports] = parse(source);
     assert.deepStrictEqual(imports, [{
       type: 'import-meta',
+      specifier: null,
+      typeOnly: false,
       start: source.indexOf('import.meta'),
       end: source.indexOf('import.meta') + 11,
       importStart: source.indexOf('import.meta'),

--- a/test/types.ts
+++ b/test/types.ts
@@ -28,8 +28,8 @@ switch (imported.type) {
     break;
   case 'import-meta':
     imported.start;
-    // @ts-expect-error import.meta references have no specifier.
-    imported.specifier;
+    imported.specifier satisfies null;
+    imported.typeOnly satisfies false;
     break;
   default: {
     const exhaustive: never = imported;

--- a/types/lexer.d.ts
+++ b/types/lexer.d.ts
@@ -116,6 +116,11 @@ export interface DynamicImport extends ImportBase {
      * // Returns "./locales/*.js"
      */
     readonly specifier: string | undefined;
+    /**
+     * True when `specifier` is a template glob rather than a literal string,
+     * since `import('a*b')` and `import(\`a${x}b\`)` both report `a*b`.
+     */
+    readonly glob: boolean;
     readonly phase: ImportPhase;
     /**
      * Start of the dynamic import expression argument.
@@ -147,6 +152,10 @@ export interface DynamicImport extends ImportBase {
  */
 export interface ImportMetaRef extends ImportBase {
     readonly type: 'import-meta';
+    /** Always `null`, so dependency loops need not narrow on `type`. */
+    readonly specifier: null;
+    /** Always `false`: an `import.meta` reference is never type-only. */
+    readonly typeOnly: false;
 }
 export type Import = StaticImport | DynamicImport | ImportMetaRef;
 export interface DirectExport {


### PR DESCRIPTION
Two record conveniences for the full build.

* `DynamicImport.glob: boolean` — `true` when `specifier` is a template glob. Without it a literal `import('a*b')` and a template `` import(`a${x}b`) `` are indistinguishable, both reporting `'a*b'`, which matters for v2 consumers whose `if (specifier)` idiom now admits globs. Substitution-free templates and concatenations report `false`.
* `ImportMetaRef.specifier: null` and `ImportMetaRef.typeOnly: false` — so `for (const { specifier, typeOnly } of imports)` works without narrowing on `type` first.

The README full-build migration paragraph now calls out the glob change and the `glob` flag; the glob section documents the flag. The minimal build is unchanged.

Tests: `glob` asserted true for the template glob and false for the literal-star, substitution-free template and concatenation forms; the dynamic and import.meta record shapes asserted exactly; the type test checks `specifier satisfies null` / `typeOnly satisfies false` on `ImportMetaRef`.
