### PR TITLE
perf: reduce parser wrapper overhead

### DIFF
--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -77,18 +77,6 @@ export function parse (_source, _name = '@') {
       n = decodeTemplate(s, e);
       glob = n !== undefined;
     }
-    let at = null;
-    // minimal build drops the parsed attribute list; es-module-shims reads the
-    // assertion via source.slice(a, se - 1) instead
-    if (!MINIMAL) {
-      at = [];
-      asm.rsa();
-      while (asm.ra()) {
-        const aks = asm.aks(), ake = asm.ake(), avs = asm.avs(), ave = asm.ave();
-        at.push([decodeIfQuoted(aks, ake), decodeIfQuoted(avs, ave)]);
-      }
-      at = at.length > 0 ? at : null;
-    }
     if (MINIMAL) {
       imports.push({ t, n, s, e, ss, se, d, a });
     }
@@ -100,6 +88,16 @@ export function parse (_source, _name = '@') {
       imports.push({ type: 'dynamic', specifier: n, glob, phase, start: s, end: e, importStart: ss, importEnd: se, dynamicStart: d, attributes: null, attributesStart: a, probablyTypeOnly: !!(importType & 16) });
     }
     else {
+      let at = null;
+      if (a !== -1) {
+        at = [];
+        asm.rsa();
+        while (asm.ra()) {
+          const aks = asm.aks(), ake = asm.ake(), avs = asm.avs(), ave = asm.ave();
+          at.push([decodeIfQuoted(aks, ake), decodeIfQuoted(avs, ave)]);
+        }
+        at = at.length > 0 ? at : null;
+      }
       const phase = t === 4/*StaticSourcePhase*/ ? 'source' : t === 6/*StaticDeferPhase*/ ? 'defer' : null;
       imports.push({ type: t === 8/*StaticReexportStar*/ ? 'reexport-star' : 'static', specifier: n, phase, start: s, end: e, importStart: ss, importEnd: se, attributes: at, attributesStart: a, typeOnly: !!(importType & 16) });
     }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -470,8 +470,12 @@ export function parse (source: string, name = '@'): readonly [
   // Buffer setup is slower than the loop for short sources.
   if (source.length >= 64 && hasBuffer)
     Buffer.from(wasm.memory.buffer, addr, (len - 1) * 2).write(source, 'utf16le');
-  else
-    (isLE ? copyLE : copyBE)(source, new Uint16Array(wasm.memory.buffer, addr, len));
+  else {
+    const memoryBuffer = wasm.memory.buffer;
+    if (sourceView?.buffer !== memoryBuffer)
+      sourceView = new Uint16Array(memoryBuffer, addr);
+    (isLE ? copyLE : copyBE)(source, sourceView);
+  }
 
   if (!wasm.parse())
     throw Object.assign(new Error(`Parse error ${name}:${source.slice(0, wasm.e()).split('\n').length}:${wasm.e() - source.lastIndexOf('\n', wasm.e() - 1)}`), { idx: wasm.e() });
@@ -488,18 +492,6 @@ export function parse (source: string, name = '@'): readonly [
       n = decodeTemplate(s, e);
       glob = n !== undefined;
     }
-    let at: Array<[string, string]> | null = null;
-    // minimal build has no attribute list; es-module-shims reads the assertion
-    // via source.slice(a, se - 1) instead
-    if (!MINIMAL) {
-      at = [];
-      wasm.rsa();
-      while (wasm.ra()) {
-        const aks = wasm.aks(), ake = wasm.ake(), avs = wasm.avs(), ave = wasm.ave();
-        at.push([decodeIfQuoted(aks, ake), decodeIfQuoted(avs, ave)]);
-      }
-      if (at.length === 0) at = null;
-    }
     if (MINIMAL) {
       imports.push({ n, t, s, e, ss, se, d, a } as unknown as Import);
     }
@@ -511,6 +503,16 @@ export function parse (source: string, name = '@'): readonly [
       imports.push({ type: 'dynamic', specifier: n, glob, phase, start: s, end: e, importStart: ss, importEnd: se, dynamicStart: d, attributes: null, attributesStart: a, probablyTypeOnly: !!(importType & 16) });
     }
     else {
+      let at: Array<[string, string]> | null = null;
+      if (a !== -1) {
+        at = [];
+        wasm.rsa();
+        while (wasm.ra()) {
+          const aks = wasm.aks(), ake = wasm.ake(), avs = wasm.avs(), ave = wasm.ave();
+          at.push([decodeIfQuoted(aks, ake), decodeIfQuoted(avs, ave)]);
+        }
+        if (at.length === 0) at = null;
+      }
       const phase: ImportPhase = t === 4/*StaticSourcePhase*/ ? 'source' : t === 6/*StaticDeferPhase*/ ? 'defer' : null;
       imports.push({ type: t === 8/*StaticReexportStar*/ ? 'reexport-star' : 'static', specifier: n!, phase, start: s, end: e, importStart: ss, importEnd: se, attributes: at, attributesStart: a, typeOnly: !!(importType & 16) });
     }
@@ -652,6 +654,7 @@ function copyLE (src: string, outBuf16: Uint16Array) {
     outBuf16[i] = src.charCodeAt(i++);
 }
 
+let sourceView: Uint16Array | undefined;
 let wasm: {
   __heap_base: {value: number} | number & {value: undefined};
   memory: WebAssembly.Memory;
@@ -725,7 +728,10 @@ const getWasmBytes = () => (
  */
 export const init = WebAssembly.compile(getWasmBytes())
 .then(WebAssembly.instantiate)
-.then(({ exports }) => { wasm = exports as typeof wasm; });
+.then(({ exports }) => {
+  sourceView = undefined;
+  wasm = exports as typeof wasm;
+});
 
 const initSync = () => {
   if (wasm) {

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const { readFile } = require('fs/promises');
 const { init, parse } = require('./_lexer.cjs');
 
@@ -202,6 +203,24 @@ suite('Lexer', () => {
     // No attributes
     assert.strictEqual(impts[5].at, null);
     assert.strictEqual(source.slice(impts[5].s, impts[5].e), 'module6');
+  });
+
+  test(`Import attributes stay attached across non-static records`, () => {
+    if (min) return;
+    const [impts] = parse(`
+      import first from 'first' with { type: 'json' }
+      import('dynamic', { with: { type: 'json' } })
+      import.meta.url
+      import noAttrs from 'no-attrs'
+      import second from 'second' with { type: 'css' }
+    `);
+    assert.deepStrictEqual(impts.map(impt => impt.at), [
+      [['type', 'json']],
+      null,
+      null,
+      null,
+      [['type', 'css']],
+    ]);
   });
 
   test(`Import attributes with quoted keys and escape sequences`, () => {
@@ -2895,15 +2914,46 @@ export { d as a, p as b, z as c, r as d, q }`;
       const { parse } = await import(min ? '../dist/lexer.minimal.js?preinit-err' : '../dist/lexer.js?preinit-err');
       assert.throws(() => parse('import{', 'my-file.js'), /^Error: Parse error my-file\.js:\d+:\d+$/);
     });
+
+    test('pre-init parse releases synchronous Wasm memory after init', () => {
+      const modulePath = min ? './dist/lexer.minimal.js?preinit-memory' : './dist/lexer.js?preinit-memory';
+      const result = spawnSync(process.execPath, [
+        '--expose-gc',
+        '--input-type=module',
+        '--eval',
+        `
+          const lexer = await import(${JSON.stringify(modulePath)});
+          lexer.parse("import 'a'");
+          await lexer.init;
+          for (let i = 0; i < 5; i++) globalThis.gc();
+          const beforeRefresh = process.memoryUsage().external;
+          lexer.parse("import 'a'");
+          for (let i = 0; i < 5; i++) globalThis.gc();
+          const retainedBytes = beforeRefresh - process.memoryUsage().external;
+          if (retainedBytes > 8 * 1024 * 1024)
+            throw new Error(\`Retained \${retainedBytes} bytes\`);
+        `,
+      ], { encoding: 'utf8' });
+      assert.strictEqual(result.status, 0, result.stderr);
+    });
   }
 
-  test('Large source', () => {
+  test('Source views survive buffer growth', () => {
+    const smallSource = `import 'small'`;
+    assert.strictEqual(parse(smallSource)[0][0].n, 'small');
+    for (const length of [63, 64, 65]) {
+      const boundarySource = `import 'boundary'`.padEnd(length);
+      assert.strictEqual(parse(boundarySource)[0][0].n, 'boundary');
+    }
+
     const source = `import 'a';\nconst x = "${'a'.repeat(5 * 1024 * 1024)}";\nexport { x }`;
     const [imports, exports] = parse(source);
     assert.strictEqual(imports.length, 1);
     assert.strictEqual(imports[0].n, 'a');
     assert.strictEqual(exports.length, 1);
     assert.strictEqual(exports[0].n, 'x');
+
+    assert.strictEqual(parse(smallSource)[0][0].n, 'small');
   });
 
   test('Entry point exports parse and init only', async () => {


### PR DESCRIPTION
Skip import-attribute reader work for records without attributes and reuse the Wasm source view below the existing Buffer threshold.

On Node 22.23.2, 20-pair CPU-time runs across 8-12 fresh processes reduce full asm.js corpus time by 5.2%. Wasm static-import workloads improve by 5.6-7.1%, and short-source workloads improve by 5.4-8.3%.

The cached view refreshes after memory growth and clears when asynchronous initialization replaces the synchronous instance.