### PR TITLE
feat!: init is now a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ With the full build:
 ```js
 import { init, parse } from 'es-module-lexer';
 
-await init;
+await init();
 
 const source = `import { a } from './dep.js';\nexport var p = 5;`;
 const [imports, exports] = parse(source);
@@ -73,7 +73,7 @@ Or with the minimal (v2-like) build:
 ```js
 import { init, parse } from 'es-module-lexer/minimal';
 
-await init;
+await init();
 
 const source = `import { a } from './dep.js';\nexport var p = 5;`;
 const [imports, exports] = parse(source);
@@ -83,8 +83,9 @@ source.slice(imports[0].ss, imports[0].se); // "import { a } from './dep.js'"
 exports[0].n; // "p"
 ```
 
-While awaiting `init` is always recommended since browser main threads restrict synchronous WebAssembly compilation,
+While awaiting `init()` is always recommended since browser main threads restrict synchronous WebAssembly compilation,
 in Node.js and other environments it may be optional, since `parse` will rely on synchronous compilation otherwise.
+Calling `parse` before a pending `init()` has resolved will also fall back to synchronous compilation, so avoid mixing the two.
 
 ## Minimal Build
 
@@ -180,7 +181,7 @@ For example:
 ```js
 import { init, parse } from 'es-module-lexer';
 
-await init;
+await init();
 
 const source = `
   import { name } from 'mod';

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ source.slice(exports[0].ls, exports[0].le);
 The minimal build is a new entry point holding the v2-shaped API, with the
 following differences from v2:
 
+* `init` is a function returning a promise rather than a promise itself:
+  `await init` becomes `await init()`. Calls are idempotent and share one
+  compilation.
 * `parse` returns `[imports, exports]` only; `facade` / `hasModuleSyntax`
   are dropped.
 * `at` is dropped from import records; read attributes via
@@ -242,7 +245,8 @@ exports[0].importIndex === 0;
 imports[0].specifier === 'dep';
 ```
 
-When migrating a full-build consumer from v2, switch on `type` before reading
+When migrating a full-build consumer from v2, `await init` becomes
+`await init()` as in the minimal build, then switch on `type` before reading
 kind-specific fields: the terse v2 field names and numeric type tags are
 replaced by the descriptive names above, reexports no longer expose
 placeholder local-name properties, and bare star reexports now appear in the

--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ following differences from v2:
 * `at` is dropped from import records; read attributes via
   `source.slice(a, se - 1)`.
 * `ImportType` is a type-only union of the numeric literals (`StaticImportType = 1`, `DynamicImportType = 2`, ...) with no runtime export.
-* Template-literal dynamic imports stay `n: undefined`; no TypeScript lexing;
-  no export classification or `export *` records.
 
 Interpolated template specifiers are not globbed in the minimal build (`n` is
 `undefined` for them), and escape sequences in specifiers are decoded into

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ source.slice(exports[0].ls, exports[0].le);
 ### Upgrading from v2
 
 The minimal build is a new entry point holding the v2-shaped API, with the
-following differences from v2:
+following small differences from v2:
 
 * `init` is a function returning a promise rather than a promise itself:
   `await init` becomes `await init()`. Calls are idempotent and share one

--- a/build/gen-min-dts.mjs
+++ b/build/gen-min-dts.mjs
@@ -80,7 +80,8 @@ export declare function parse(source: string, name?: string): readonly [
 ];
 
 /**
- * Wait for init to resolve before calling \`parse\`.
+ * Asynchronously compile the lexer. Await the returned promise before
+ * calling \`parse\`. Idempotent: repeated calls share the same promise.
  */
-export declare const init: Promise<void>;
+export declare const init: () => Promise<void>;
 `);

--- a/src/lexer.asm.js
+++ b/src/lexer.asm.js
@@ -27,7 +27,7 @@ const words = {{WORDS}};
 
 let source, name;
 // The asm.js module needs no compilation step; kept for the shared wasm build API.
-export const init = Promise.resolve();
+export const init = () => Promise.resolve();
 
 export function parse (_source, _name = '@') {
   source = _source;

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -452,7 +452,7 @@ export function parse (source: string, name = '@'): readonly [
   hasModuleSyntax: boolean
 ] {
   if (!wasm)
-    // synchronous compile is restricted on browser main threads — await init
+    // synchronous compile is restricted on browser main threads — await init()
     // there before calling parse
     initSync();
 
@@ -723,15 +723,18 @@ const getWasmBytes = () => (
     : Uint8Array.from(atob(binary), x => x.charCodeAt(0))
 )('WASM_BINARY');
 
+let initPromise: Promise<void> | undefined;
+
 /**
- * Wait for init to resolve before calling `parse`.
+ * Asynchronously compile the lexer. Await the returned promise before
+ * calling `parse`. Idempotent: repeated calls share the same promise.
  */
-export const init = WebAssembly.compile(getWasmBytes())
-.then(WebAssembly.instantiate)
-.then(({ exports }) => {
-  sourceView = undefined;
-  wasm = exports as typeof wasm;
-});
+export const init = (): Promise<void> => initPromise || (initPromise = wasm
+  ? Promise.resolve()
+  : WebAssembly.compile(getWasmBytes())
+    .then(WebAssembly.instantiate)
+    // parse may already have compiled synchronously while this was pending
+    .then(({ exports }) => { if (!wasm) wasm = exports as typeof wasm; }));
 
 const initSync = () => {
   if (wasm) {

--- a/test/_lexer.cjs
+++ b/test/_lexer.cjs
@@ -11,7 +11,7 @@ async function loadLexer() {
   }
   else {
     const lexer = await import(minimal ? '../dist/lexer.minimal.js' : '../dist/lexer.js');
-    await lexer.init;
+    await lexer.init();
     lexerParse = lexer.parse;
   }
 }

--- a/test/_unit.cjs
+++ b/test/_unit.cjs
@@ -2961,7 +2961,12 @@ export { d as a, p as b, z as c, r as d, q }`;
       ? (min ? '../dist/lexer.minimal.asm.js' : '../dist/lexer.asm.js')
       : (min ? '../dist/lexer.minimal.js' : '../dist/lexer.js'));
     assert.deepStrictEqual(Object.keys(m).sort(), ['init', 'parse']);
-    await m.init;
+    assert.strictEqual(typeof m.init, 'function');
+    const p = m.init();
+    assert(p instanceof Promise);
+    // the wasm builds memoize the compile; the asm.js shim just resolves
+    if (process.env.WASM) assert.strictEqual(m.init(), p);
+    await p;
     assert.strictEqual(m.parse('export const a = 1')[1].length, 1);
   });
 

--- a/test/full-api.cjs
+++ b/test/full-api.cjs
@@ -11,7 +11,7 @@ const init = (async () => {
   }
   else {
     const m = await import('../dist/lexer.js');
-    await m.init;
+    await m.init();
     parse = m.parse;
   }
 })();

--- a/test/fuzz-ts.mjs
+++ b/test/fuzz-ts.mjs
@@ -30,7 +30,7 @@ const ENGINE = process.env.FUZZ_ENGINE === 'asm'
   ? '../dist/lexer.asm.js'
   : '../dist/lexer.js';
 const mod = await import(new URL(ENGINE, import.meta.url).href);
-if (mod.init) await mod.init;
+if (mod.init) await mod.init();
 const parse = mod.parse;
 
 const ONLY_FORM = process.env.FORM;

--- a/test/integration.cjs
+++ b/test/integration.cjs
@@ -5,7 +5,7 @@ const init = (async () => {
   if (parse) return;
   if (process.env.WASM) {
     const m = await import('../dist/lexer.js');
-    await m.init;
+    await m.init();
     parse = m.parse;
   }
   else {

--- a/test/legacy.html
+++ b/test/legacy.html
@@ -28,7 +28,7 @@ function checkFull (parse, label) {
 Promise.resolve()
   .then(function () { checkMin(parseMinAsm, 'minimal asm.js'); })
   .then(function () { checkFull(parseFullAsm, 'full asm.js'); })
-  .then(function () { return init; })
+  .then(function () { return init(); })
   .then(function () { checkMin(parseMinWasm, 'minimal wasm'); })
   .then(function () { document.title = 'PASS'; })
   .catch(function (err) { document.title = 'FAIL: ' + err.message; });

--- a/test/no-eval/index.cjs
+++ b/test/no-eval/index.cjs
@@ -9,7 +9,7 @@ suite('No string code generation', () => {
     const lexer = commonjs
       ? require(minimal ? '../../dist/lexer.minimal.cjs' : '../../dist/lexer.cjs')
       : await import(minimal ? '../../dist/lexer.minimal.js' : '../../dist/lexer.js');
-    await lexer.init;
+    await lexer.init();
     parse = lexer.parse;
     assert.throws(() => eval('1'), EvalError);
   });

--- a/types/lexer.d.ts
+++ b/types/lexer.d.ts
@@ -303,7 +303,8 @@ export declare function parse(source: string, name?: string): readonly [
     hasModuleSyntax: boolean
 ];
 /**
- * Wait for init to resolve before calling `parse`.
+ * Asynchronously compile the lexer. Await the returned promise before
+ * calling `parse`. Idempotent: repeated calls share the same promise.
  */
-export declare const init: Promise<void>;
+export declare const init: () => Promise<void>;
 export {};

--- a/types/lexer.minimal.d.ts
+++ b/types/lexer.minimal.d.ts
@@ -73,6 +73,7 @@ export declare function parse(source: string, name?: string): readonly [
 ];
 
 /**
- * Wait for init to resolve before calling `parse`.
+ * Asynchronously compile the lexer. Await the returned promise before
+ * calling `parse`. Idempotent: repeated calls share the same promise.
  */
-export declare const init: Promise<void>;
+export declare const init: () => Promise<void>;


### PR DESCRIPTION
`init` is now a function returning a memoized promise rather than a promise created at module load:

```js
import { init, parse } from 'es-module-lexer';
await init();
```

- Compilation no longer starts on import; it starts on the first \`init()\` call, and repeated calls share the same promise.
- If \`parse\` has already compiled synchronously, \`init()\` resolves immediately without recompiling.
- If \`parse\` runs while an \`init()\` is pending, the async result no longer replaces the already-installed instance.
- The asm.js builds export a matching \`init\` function.
- Types, README and tests updated.

Breaking for existing \`await init\` usage; landing within the 3.0.0 window.